### PR TITLE
Fix lightness assertion ranges

### DIFF
--- a/flutter_color_models/lib/src/models/oklab_color.dart
+++ b/flutter_color_models/lib/src/models/oklab_color.dart
@@ -108,7 +108,7 @@ class OklabColor extends cm.OklabColor
   @override
   OklabColor withValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
-    assert(values[0] >= 0 && values[0] <= 100);
+    assert(values[0] >= 0.0 && values[0] <= 1.0);
     assert(values[1] >= -128 && values[1] <= 127);
     assert(values[2] >= -128 && values[2] <= 127);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
@@ -118,7 +118,7 @@ class OklabColor extends cm.OklabColor
 
   @override
   OklabColor copyWith({num? lightness, num? a, num? b, int? alpha}) {
-    assert(lightness == null || (lightness >= 0 && lightness <= 100));
+    assert(lightness == null || (lightness >= 0.0 && lightness <= 1.0));
     assert(a == null || (a >= -128 && a <= 127));
     assert(b == null || (b >= -128 && b <= 127));
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
@@ -139,7 +139,7 @@ class OklabColor extends cm.OklabColor
   /// {@macro color_models.OklabColor.fromList}
   factory OklabColor.fromList(List<double> values) {
     assert(values.length == 3 || values.length == 4);
-    assert(values[0] >= 0 && values[0] <= 100);
+    assert(values[0] >= 0.0 && values[0] <= 1.0);
     assert(values[1] >= -128 && values[1] <= 127);
     assert(values[2] >= -128 && values[2] <= 127);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);

--- a/flutter_color_models/lib/src/models/oklab_color.dart
+++ b/flutter_color_models/lib/src/models/oklab_color.dart
@@ -109,8 +109,8 @@ class OklabColor extends cm.OklabColor
   OklabColor withValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0.0 && values[0] <= 1.0);
-    assert(values[1] >= -128 && values[1] <= 127);
-    assert(values[2] >= -128 && values[2] <= 127);
+    assert(values[1] >= 0.0 && values[1] <= 1.0);
+    assert(values[2] >= 0.0 && values[2] <= 1.0);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(
         values.map<double>((value) => value.toDouble()).toList());
@@ -119,8 +119,8 @@ class OklabColor extends cm.OklabColor
   @override
   OklabColor copyWith({num? lightness, num? a, num? b, int? alpha}) {
     assert(lightness == null || (lightness >= 0.0 && lightness <= 1.0));
-    assert(a == null || (a >= -128 && a <= 127));
-    assert(b == null || (b >= -128 && b <= 127));
+    assert(a == null || (a >= 0.0 && a <= 1.0));
+    assert(b == null || (b >= 0.0 && b <= 1.0));
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return OklabColor(
       lightness?.toDouble() ?? this.lightness,
@@ -140,8 +140,8 @@ class OklabColor extends cm.OklabColor
   factory OklabColor.fromList(List<double> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0.0 && values[0] <= 1.0);
-    assert(values[1] >= -128 && values[1] <= 127);
-    assert(values[2] >= -128 && values[2] <= 127);
+    assert(values[1] >= 0.0 && values[1] <= 1.0);
+    assert(values[2] >= 0.0 && values[2] <= 1.0);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     final alpha = values.length == 4 ? values[3].round() : 255;
     return OklabColor(values[0], values[1], values[2], alpha);


### PR DESCRIPTION
Assertions incorrectly use 0-100 and -128 to 127, while the underlying Oklab class uses 0-1 for all variables