### PR TITLE
Forward fix for wide gamut changes in colors

### DIFF
--- a/color_models/lib/src/color_model.dart
+++ b/color_models/lib/src/color_model.dart
@@ -92,7 +92,7 @@ abstract class ColorModel {
         : toListWithAlpha();
     final valuesB =
         end is RgbColor ? end.toPreciseListWithAlpha() : end.toListWithAlpha();
-    return withValues(List<num>.generate(valuesA.length,
+    return fromValues(List<num>.generate(valuesA.length,
         (index) => _interpolateValue(valuesA[index], valuesB[index], step)));
   }
 
@@ -131,7 +131,7 @@ abstract class ColorModel {
       for (var j = 0; j < valuesA.length; j++) {
         values.add(_interpolateValue(valuesA[j], valuesB[j], step));
       }
-      colors.add(colorA.withValues(values));
+      colors.add(colorA.fromValues(values));
     }
 
     if (!excludeOriginalColors) {
@@ -198,7 +198,7 @@ abstract class ColorModel {
   ///
   /// [values] should contain one value for each parameter of the color space;
   /// the alpha value is optional.
-  ColorModel withValues(List<num> values);
+  ColorModel fromValues(List<num> values);
 
   /// Returns a copy of this color modified with the provided values.
   ColorModel copyWith({int? alpha});

--- a/color_models/lib/src/helpers/color_converter.dart
+++ b/color_models/lib/src/helpers/color_converter.dart
@@ -508,8 +508,8 @@ class ColorConverter {
   /// Converts a XYZ color to a LAB color.
   static XyzColor labToXyz(LabColor labColor) {
     final lightness = labColor.lightness;
-    final a = labColor.a;
-    final b = labColor.b;
+    final a = labColor.chromaticityA;
+    final b = labColor.chromaticityB;
 
     var y = (lightness + 16) / 116;
     var x = (a / 500) + y;

--- a/color_models/lib/src/helpers/color_converter.dart
+++ b/color_models/lib/src/helpers/color_converter.dart
@@ -578,16 +578,16 @@ class ColorConverter {
     }
 
     final l = (oklabColor.lightness +
-            (0.3963377774 * oklabColor.a) +
-            (0.2158037573 * oklabColor.b))
+            (0.3963377774 * oklabColor.chromaticityA) +
+            (0.2158037573 * oklabColor.chromaticityB))
         .cubed();
     final m = (oklabColor.lightness -
-            (0.1055613458 * oklabColor.a) -
-            (0.0638541728 * oklabColor.b))
+            (0.1055613458 * oklabColor.chromaticityA) -
+            (0.0638541728 * oklabColor.chromaticityB))
         .cubed();
     final s = (oklabColor.lightness -
-            (0.0894841775 * oklabColor.a) -
-            (1.2914855480 * oklabColor.b))
+            (0.0894841775 * oklabColor.chromaticityA) -
+            (1.2914855480 * oklabColor.chromaticityB))
         .cubed();
 
     return _LinearRgbColor(

--- a/color_models/lib/src/models/cmyk_color.dart
+++ b/color_models/lib/src/models/cmyk_color.dart
@@ -154,7 +154,7 @@ class CmykColor extends ColorModel {
   }
 
   @override
-  CmykColor withValues(List<num> values) {
+  CmykColor fromValues(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsb_color.dart
+++ b/color_models/lib/src/models/hsb_color.dart
@@ -141,7 +141,7 @@ class HsbColor extends ColorModel {
   }
 
   @override
-  HsbColor withValues(List<num> values) {
+  HsbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsi_color.dart
+++ b/color_models/lib/src/models/hsi_color.dart
@@ -141,7 +141,7 @@ class HsiColor extends ColorModel {
   }
 
   @override
-  HsiColor withValues(List<num> values) {
+  HsiColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsl_color.dart
+++ b/color_models/lib/src/models/hsl_color.dart
@@ -144,7 +144,7 @@ class HslColor extends ColorModel {
   }
 
   @override
-  HslColor withValues(List<num> values) {
+  HslColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsp_color.dart
+++ b/color_models/lib/src/models/hsp_color.dart
@@ -148,7 +148,7 @@ class HspColor extends ColorModel {
   }
 
   @override
-  HspColor withValues(List<num> values) {
+  HspColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/lab_color.dart
+++ b/color_models/lib/src/models/lab_color.dart
@@ -21,19 +21,19 @@ class LabColor extends ColorModel {
   ///
   /// [lightness] must be `>= 0` and `<= 100`.
   ///
-  /// [a] and [b] must both be `>= -128` and `<= 127`.
+  /// [chromaticityA] and [b] must both be `>= -128` and `<= 127`.
   ///
   /// [alpha] must be `>= 0` and `<= 255`.
   ///
   /// {@endtemplate}
   const LabColor(
     this.lightness,
-    this.a,
-    this.b, [
+    this.chromaticityA,
+    this.chromaticityB, [
     int alpha = 255,
   ])  : assert(lightness >= 0 && lightness <= 100),
-        assert(a >= -128 && a <= 127),
-        assert(b >= -128 && b <= 127),
+        assert(chromaticityA >= -128 && chromaticityA <= 127),
+        assert(chromaticityB >= -128 && chromaticityB <= 127),
         assert(alpha >= 0 && alpha <= 255),
         super(alpha: alpha);
 
@@ -47,30 +47,30 @@ class LabColor extends ColorModel {
   /// Green is represented in the negative value range (`-128` to `0`)
   ///
   /// Red is represented in the positive value range (`0` to `127`)
-  final num a;
+  final num chromaticityA;
 
   /// The yellow to blue opponent color value.
   ///
   /// Yellow is represented int he negative value range (`-128` to `0`)
   ///
   /// Blue is represented in the positive value range (`0` to `127`)
-  final num b;
+  final num chromaticityB;
 
   @override
   bool get isBlack =>
       ColorMath.round(lightness) == 0 &&
-      ColorMath.round(a) == 0 &&
-      ColorMath.round(b) == 0;
+      ColorMath.round(chromaticityA) == 0 &&
+      ColorMath.round(chromaticityB) == 0;
 
   @override
   bool get isWhite =>
       ColorMath.round(lightness) == 1 &&
-      ColorMath.round(a) == 0 &&
-      ColorMath.round(b) == 0;
+      ColorMath.round(chromaticityA) == 0 &&
+      ColorMath.round(chromaticityB) == 0;
 
   @override
   bool get isMonochromatic =>
-      ColorMath.round(a) == 0 && ColorMath.round(b) == 0;
+      ColorMath.round(chromaticityA) == 0 && ColorMath.round(chromaticityB) == 0;
 
   @override
   LabColor interpolate(ColorModel end, double step) {
@@ -95,7 +95,7 @@ class LabColor extends ColorModel {
 
   @override
   LabColor get inverted => LabColor(
-      100 - lightness, 255 - (a + 128) - 128, 255 - (b + 128) - 128, alpha);
+      100 - lightness, 255 - (chromaticityA + 128) - 128, 255 - (chromaticityB + 128) - 128, alpha);
 
   @override
   LabColor get opposite => rotateHue(180);
@@ -138,7 +138,7 @@ class LabColor extends ColorModel {
   @override
   LabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return LabColor(lightness, a, b, alpha);
+    return LabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -165,8 +165,8 @@ class LabColor extends ColorModel {
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return LabColor(
       lightness ?? this.lightness,
-      a ?? this.a,
-      b ?? this.b,
+      a ?? this.chromaticityA,
+      b ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }
@@ -183,13 +183,13 @@ class LabColor extends ColorModel {
   /// Returns a fixed-length list containing the [lightness],
   /// [a], and [b] values, in that order.
   @override
-  List<num> toList() => List<num>.from(<num>[lightness, a, b], growable: false);
+  List<num> toList() => List<num>.from(<num>[lightness, chromaticityA, chromaticityB], growable: false);
 
   /// Returns a fixed-length list containing the [lightness],
   /// [a], [b], and [alpha] values, in that order.
   @override
   List<num> toListWithAlpha() =>
-      List<num>.from(<num>[lightness, a, b, alpha], growable: false);
+      List<num>.from(<num>[lightness, chromaticityA, chromaticityB, alpha], growable: false);
 
   /// {@template color_models.LabColor.from}
   ///
@@ -259,9 +259,9 @@ class LabColor extends ColorModel {
   /// [minLightness] and [maxLightness] constrain the generated [lightness]
   /// value.
   ///
-  /// [minA] and [maxA] constrain the generated [a] value.
+  /// [minA] and [maxA] constrain the generated [chromaticityA] value.
   ///
-  /// [minB] and [maxB] constrain the generated [b] value.
+  /// [minB] and [maxB] constrain the generated [chromaticityB] value.
   ///
   /// All min and max values must be `min <= max && max >= min`, must
   /// be in the range of `>= 0 && <= 100`, and must not be `null`.
@@ -293,17 +293,17 @@ class LabColor extends ColorModel {
   LabColor convert(ColorModel other) => other.toLabColor();
 
   @override
-  String toString() => 'LabColor($lightness, $a, $b, $alpha)';
+  String toString() => 'LabColor($lightness, $chromaticityA, $chromaticityB, $alpha)';
 
   @override
   bool operator ==(Object other) =>
       other is LabColor &&
       ColorMath.round(lightness) == ColorMath.round(other.lightness) &&
-      ColorMath.round(a) == ColorMath.round(other.a) &&
-      ColorMath.round(b) == ColorMath.round(other.b) &&
+      ColorMath.round(chromaticityA) == ColorMath.round(other.chromaticityA) &&
+      ColorMath.round(chromaticityB) == ColorMath.round(other.chromaticityB) &&
       alpha == other.alpha;
 
   @override
   int get hashCode =>
-      lightness.hashCode ^ a.hashCode ^ b.hashCode ^ alpha.hashCode;
+      lightness.hashCode ^ chromaticityA.hashCode ^ chromaticityB.hashCode ^ alpha.hashCode;
 }

--- a/color_models/lib/src/models/lab_color.dart
+++ b/color_models/lib/src/models/lab_color.dart
@@ -148,7 +148,7 @@ class LabColor extends ColorModel {
   }
 
   @override
-  LabColor withValues(List<num> values) {
+  LabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= -128 && values[1] <= 127);

--- a/color_models/lib/src/models/oklab_color.dart
+++ b/color_models/lib/src/models/oklab_color.dart
@@ -149,7 +149,7 @@ class OklabColor extends ColorModel {
   }
 
   @override
-  OklabColor withValues(List<num> values) {
+  OklabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(values);

--- a/color_models/lib/src/models/oklab_color.dart
+++ b/color_models/lib/src/models/oklab_color.dart
@@ -22,7 +22,7 @@ class OklabColor extends ColorModel {
   ///
   /// A color in the Oklab color space.
   ///
-  /// [lightness], [a], and [b]'s normal range is `0.0` to `1.0`,
+  /// [lightness], [chromaticityA], and [b]'s normal range is `0.0` to `1.0`,
   /// but some colors may fall slightly outside of it.
   ///
   /// [alpha] must be `>= 0` and `<= 255`.
@@ -32,8 +32,8 @@ class OklabColor extends ColorModel {
   /// {@endtemplate}
   const OklabColor(
     this.lightness,
-    this.a,
-    this.b, [
+    this.chromaticityA,
+    this.chromaticityB, [
     int alpha = 255,
   ])  : assert(alpha >= 0 && alpha <= 255),
         super(alpha: alpha);
@@ -46,28 +46,28 @@ class OklabColor extends ColorModel {
   /// The red to green opponent color value.
   ///
   /// The value ranges from red at `0.0` to green at `1.0`.
-  final double a;
+  final double chromaticityA;
 
   /// The yellow to blue opponent color value.
   ///
   /// The value ranges from yellow at `0.0` to blue at `1.0`.
-  final double b;
+  final double chromaticityB;
 
   @override
   bool get isBlack =>
       ColorMath.round(lightness) <= 0 &&
-      ColorMath.round(a) <= 0 &&
-      ColorMath.round(b) <= 0;
+      ColorMath.round(chromaticityA) <= 0 &&
+      ColorMath.round(chromaticityB) <= 0;
 
   @override
   bool get isWhite =>
       ColorMath.round(lightness) >= 1 &&
-      ColorMath.round(a) <= 0 &&
-      ColorMath.round(b) <= 0;
+      ColorMath.round(chromaticityA) <= 0 &&
+      ColorMath.round(chromaticityB) <= 0;
 
   @override
   bool get isMonochromatic =>
-      ColorMath.round(a) == 0 && ColorMath.round(b) == 0;
+      ColorMath.round(chromaticityA) == 0 && ColorMath.round(chromaticityB) == 0;
 
   @override
   OklabColor interpolate(ColorModel end, double step) {
@@ -92,7 +92,7 @@ class OklabColor extends ColorModel {
 
   @override
   OklabColor get inverted =>
-      OklabColor(1.0 - lightness, 1.0 - a, 1.0 - b, alpha);
+      OklabColor(1.0 - lightness, 1.0 - chromaticityA, 1.0 - chromaticityB, alpha);
 
   @override
   OklabColor get opposite => rotateHue(180);
@@ -139,7 +139,7 @@ class OklabColor extends ColorModel {
   @override
   OklabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return OklabColor(lightness, a, b, alpha);
+    return OklabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -163,13 +163,13 @@ class OklabColor extends ColorModel {
     int? alpha,
   }) {
     assert(lightness == null || (lightness >= 0 && lightness <= 1.0));
-    assert(a == null || (a >= 0 && a <= 1.0));
-    assert(b == null || (b >= 0 && b <= 1.0));
+    assert(a == null || (chromaticityA >= 0 && chromaticityA <= 1.0));
+    assert(b == null || (chromaticityB >= 0 && chromaticityB <= 1.0));
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return OklabColor(
       lightness ?? this.lightness,
-      a ?? this.a,
-      b ?? this.b,
+      a ?? this.chromaticityA,
+      b ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }
@@ -184,13 +184,13 @@ class OklabColor extends ColorModel {
   /// [a], and [b] values, in that order.
   @override
   List<double> toList() =>
-      List<double>.from(<double>[lightness, a, b], growable: false);
+      List<double>.from(<double>[lightness, chromaticityA, chromaticityB], growable: false);
 
   /// Returns a fixed-length list containing the [lightness],
   /// [a], [b], and [alpha] values, in that order.
   @override
   List<num> toListWithAlpha() =>
-      List<num>.from(<num>[lightness, a, b, alpha], growable: false);
+      List<num>.from(<num>[lightness, chromaticityA, chromaticityB, alpha], growable: false);
 
   /// {@template color_models.OklabColor.from}
   ///
@@ -262,17 +262,17 @@ class OklabColor extends ColorModel {
   OklabColor convert(ColorModel other) => other.toOklabColor();
 
   @override
-  String toString() => 'OklabColor($lightness, $a, $b, $alpha)';
+  String toString() => 'OklabColor($lightness, $chromaticityA, $chromaticityB, $alpha)';
 
   @override
   bool operator ==(Object other) =>
       other is OklabColor &&
       ColorMath.round(lightness) == ColorMath.round(other.lightness) &&
-      ColorMath.round(a) == ColorMath.round(other.a) &&
-      ColorMath.round(b) == ColorMath.round(other.b) &&
+      ColorMath.round(chromaticityA) == ColorMath.round(other.chromaticityA) &&
+      ColorMath.round(chromaticityA) == ColorMath.round(other.chromaticityB) &&
       alpha == other.alpha;
 
   @override
   int get hashCode =>
-      lightness.hashCode ^ a.hashCode ^ b.hashCode ^ alpha.hashCode;
+      lightness.hashCode ^ chromaticityA.hashCode ^ chromaticityB.hashCode ^ alpha.hashCode;
 }

--- a/color_models/lib/src/models/rgb_color.dart
+++ b/color_models/lib/src/models/rgb_color.dart
@@ -151,7 +151,7 @@ class RgbColor extends ColorModel {
   }
 
   @override
-  RgbColor withValues(List<num> values) {
+  RgbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 255);
     assert(values[1] >= 0 && values[1] <= 255);

--- a/color_models/lib/src/models/xyz_color.dart
+++ b/color_models/lib/src/models/xyz_color.dart
@@ -154,7 +154,7 @@ class XyzColor extends ColorModel {
   }
 
   @override
-  XyzColor withValues(List<num> values) {
+  XyzColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0);
     assert(values[1] >= 0);

--- a/flutter_color_models/CHANGELOG.md
+++ b/flutter_color_models/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.0] - August 23, 2024
+
+* Prepares for the coming changes in Flutter's Color class
+  * upgrades color_models
+  * adds Color.a, Color.r, Color.g, Color.b, Color.withValues, Color.colorSpace.
+
 ## [1.3.3] - January 18, 2023
 
 * Added the [toColors] helper method to [Iterable<ColorModel>].

--- a/flutter_color_models/CHANGELOG.md
+++ b/flutter_color_models/CHANGELOG.md
@@ -59,7 +59,7 @@ the [RgbColor] object from `color_models`.
 * Implemented the Oklab color space as [OklabColor].
 
 * Added the [castTo], [convert], [copyWith], [interpolate], and
-[withValues] methods to every color model.
+[fromValues] methods to every color model.
 
 * Deprecated the `withXXX` methods being replaced by the [copyWith] method.
 

--- a/flutter_color_models/lib/src/color_model.dart
+++ b/flutter_color_models/lib/src/color_model.dart
@@ -68,7 +68,7 @@ abstract class ColorModel implements cm.ColorModel, Color {
   ColorModel withOpacity(double opacity);
 
   @override
-  ColorModel withValues(List<num> values);
+  ColorModel fromValues(List<num> values);
 
   @override
   ColorModel copyWith({int? alpha});

--- a/flutter_color_models/lib/src/models/cmyk_color.dart
+++ b/flutter_color_models/lib/src/models/cmyk_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.CmykColor}
 class CmykColor extends cm.CmykColor
@@ -120,6 +121,16 @@ class CmykColor extends cm.CmykColor
     assert(values[2] >= 0 && values[2] <= 100);
     assert(values[3] >= 0 && values[3] <= 100);
     return CmykColor.fromList(values);
+  }
+
+  CmykColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return CmykColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/cmyk_color.dart
+++ b/flutter_color_models/lib/src/models/cmyk_color.dart
@@ -113,7 +113,7 @@ class CmykColor extends cm.CmykColor
   }
 
   @override
-  CmykColor withValues(List<num> values) {
+  CmykColor fromValues(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/flutter_color_models/lib/src/models/helpers/as_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/as_color.dart
@@ -1,6 +1,30 @@
 import 'package:color_models/color_models.dart' show ColorModel;
 import 'package:flutter/painting.dart' show Color;
 import 'dart:math' as math show pow;
+import 'dart:ui' as ui;
+
+extension ColorModelWithValues on ColorModel {
+  Color performWithValues(double? alpha, double? red, double? green,
+      double? blue, ui.ColorSpace? colorSpace) {
+    // TODO(gaaclarke): This is inefficient and will be easier to rewrite once
+    // the changes come through on Color.
+    assert(colorSpace == null || colorSpace == ui.ColorSpace.sRGB);
+    Color color = toRgbColor() as Color;
+    if (alpha != null) {
+      color = color.withAlpha(alpha ~/ 255.0);
+    }
+    if (red != null) {
+      color = color.withRed(red ~/ 255.0);
+    }
+    if (green != null) {
+      color = color.withGreen(green ~/ 255.0);
+    }
+    if (blue != null) {
+      color = color.withBlue(blue ~/ 255.0);
+    }
+    return color;
+  }
+}
 
 /// The getters and methods required to implement Flutter's [Color] class.
 mixin AsColor on ColorModel {
@@ -13,6 +37,8 @@ mixin AsColor on ColorModel {
   /// * Bits 8-15 are the green value.
   /// * Bits 0-7 are the blue value.
   int get value;
+
+  ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
 
   /// See <https://www.w3.org/TR/WCAG20/#relativeluminancedef>
   ///

--- a/flutter_color_models/lib/src/models/helpers/as_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/as_color.dart
@@ -38,6 +38,8 @@ mixin AsColor on ColorModel {
   /// * Bits 0-7 are the blue value.
   int get value;
 
+  int toARGB32() => value;
+
   ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
 
   /// See <https://www.w3.org/TR/WCAG20/#relativeluminancedef>

--- a/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
@@ -188,13 +188,13 @@ extension CastFromHspColor on HspColor {
 extension CastToLabColor on cm.LabColor {
   /// Casts a [LabColor] from the `color_models` package to a
   /// [LabColor] from the `flutter_color_models` package.
-  LabColor cast() => LabColor(lightness, a, b, alpha);
+  LabColor cast() => LabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastFromLabColor on LabColor {
   /// Casts a [LabColor] from the `color_models` package to a
   /// [LabColor] from the `flutter_color_models` package.
-  cm.LabColor cast() => cm.LabColor(lightness, a, b, alpha);
+  cm.LabColor cast() => cm.LabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastToOklabColor on cm.OklabColor {

--- a/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
@@ -200,13 +200,13 @@ extension CastFromLabColor on LabColor {
 extension CastToOklabColor on cm.OklabColor {
   /// Casts a [OklabColor] from the `color_models` package to a
   /// [OklabColor] from the `flutter_color_models` package.
-  OklabColor cast() => OklabColor(lightness, a, b, alpha);
+  OklabColor cast() => OklabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastFromOklabColor on OklabColor {
   /// Casts a [OklabColor] from the `color_models` package to a
   /// [OklabColor] from the `flutter_color_models` package.
-  cm.OklabColor cast() => cm.OklabColor(lightness, a, b, alpha);
+  cm.OklabColor cast() => cm.OklabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastToRgbColor on cm.RgbColor {

--- a/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
+++ b/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
@@ -10,11 +10,11 @@ mixin RgbGetters on ColorModel {
   /// The blue value of this color.
   int get blue => toRgbColor().blue;
 
-  double get a => alpha / 255.0;
+  // double get a => alpha / 255.0;
 
-  double get r => toRgbColor().red / 255.0;
+  // double get r => red / 255.0;
 
-  double get g => toRgbColor().green / 255.0;
+  // double get g => green / 255.0;
 
-  double get b => toRgbColor().blue / 255.0;
+  // double get b => blue / 255.0;
 }

--- a/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
+++ b/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
@@ -9,4 +9,12 @@ mixin RgbGetters on ColorModel {
 
   /// The blue value of this color.
   int get blue => toRgbColor().blue;
+
+  double get a => alpha / 255.0;
+
+  double get r => toRgbColor().red / 255.0;
+
+  double get g => toRgbColor().green / 255.0;
+
+  double get b => toRgbColor().blue / 255.0;
 }

--- a/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
+++ b/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
@@ -10,11 +10,11 @@ mixin RgbGetters on ColorModel {
   /// The blue value of this color.
   int get blue => toRgbColor().blue;
 
-  // double get a => alpha / 255.0;
+  double get a => alpha / 255.0;
 
-  // double get r => red / 255.0;
+  double get r => red / 255.0;
 
-  // double get g => green / 255.0;
+  double get g => green / 255.0;
 
-  // double get b => blue / 255.0;
+  double get b => blue / 255.0;
 }

--- a/flutter_color_models/lib/src/models/hsb_color.dart
+++ b/flutter_color_models/lib/src/models/hsb_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.HsbColor}
 class HsbColor extends cm.HsbColor
@@ -117,6 +118,16 @@ class HsbColor extends cm.HsbColor
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HsbColor.fromList(values);
+  }
+
+  HsbColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HsbColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/hsb_color.dart
+++ b/flutter_color_models/lib/src/models/hsb_color.dart
@@ -110,7 +110,7 @@ class HsbColor extends cm.HsbColor
   }
 
   @override
-  HsbColor withValues(List<num> values) {
+  HsbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/flutter_color_models/lib/src/models/hsi_color.dart
+++ b/flutter_color_models/lib/src/models/hsi_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.HsiColor}
 class HsiColor extends cm.HsiColor
@@ -117,6 +118,16 @@ class HsiColor extends cm.HsiColor
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HsiColor.fromList(values);
+  }
+
+  HsiColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HsiColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/hsi_color.dart
+++ b/flutter_color_models/lib/src/models/hsi_color.dart
@@ -110,7 +110,7 @@ class HsiColor extends cm.HsiColor
   }
 
   @override
-  HsiColor withValues(List<num> values) {
+  HsiColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/flutter_color_models/lib/src/models/hsl_color.dart
+++ b/flutter_color_models/lib/src/models/hsl_color.dart
@@ -110,7 +110,7 @@ class HslColor extends cm.HslColor
   }
 
   @override
-  HslColor withValues(List<num> values) {
+  HslColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/flutter_color_models/lib/src/models/hsl_color.dart
+++ b/flutter_color_models/lib/src/models/hsl_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.HslColor}
 class HslColor extends cm.HslColor
@@ -117,6 +118,16 @@ class HslColor extends cm.HslColor
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HslColor.fromList(values);
+  }
+
+  HslColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HslColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/hsp_color.dart
+++ b/flutter_color_models/lib/src/models/hsp_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.HspColor}
 class HspColor extends cm.HspColor
@@ -117,6 +118,16 @@ class HspColor extends cm.HspColor
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HspColor.fromList(values);
+  }
+
+  HspColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HspColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/hsp_color.dart
+++ b/flutter_color_models/lib/src/models/hsp_color.dart
@@ -110,7 +110,7 @@ class HspColor extends cm.HspColor
   }
 
   @override
-  HspColor withValues(List<num> values) {
+  HspColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/flutter_color_models/lib/src/models/lab_color.dart
+++ b/flutter_color_models/lib/src/models/lab_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.LabColor}
 class LabColor extends cm.LabColor
@@ -119,6 +120,16 @@ class LabColor extends cm.LabColor
     assert(values[2] >= -128 && values[2] <= 127);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return LabColor.fromList(values);
+  }
+
+  LabColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return LabColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/lab_color.dart
+++ b/flutter_color_models/lib/src/models/lab_color.dart
@@ -103,7 +103,7 @@ class LabColor extends cm.LabColor
   @override
   LabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return LabColor(lightness, a, b, alpha);
+    return LabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -140,8 +140,8 @@ class LabColor extends cm.LabColor
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return LabColor(
       lightness ?? this.lightness,
-      a ?? this.a,
-      b ?? this.b,
+      a ?? this.chromaticityA,
+      b ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }

--- a/flutter_color_models/lib/src/models/lab_color.dart
+++ b/flutter_color_models/lib/src/models/lab_color.dart
@@ -112,7 +112,7 @@ class LabColor extends cm.LabColor
   }
 
   @override
-  LabColor withValues(List<num> values) {
+  LabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= -128 && values[1] <= 127);

--- a/flutter_color_models/lib/src/models/oklab_color.dart
+++ b/flutter_color_models/lib/src/models/oklab_color.dart
@@ -100,7 +100,7 @@ class OklabColor extends cm.OklabColor
   @override
   OklabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return OklabColor(lightness, a, b, alpha);
+    return OklabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -135,8 +135,8 @@ class OklabColor extends cm.OklabColor
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return OklabColor(
       lightness?.toDouble() ?? this.lightness,
-      a?.toDouble() ?? this.a,
-      b?.toDouble() ?? this.b,
+      a?.toDouble() ?? this.chromaticityA,
+      b?.toDouble() ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }

--- a/flutter_color_models/lib/src/models/oklab_color.dart
+++ b/flutter_color_models/lib/src/models/oklab_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.OklabColor}
 class OklabColor extends cm.OklabColor
@@ -114,6 +115,16 @@ class OklabColor extends cm.OklabColor
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(
         values.map<double>((value) => value.toDouble()).toList());
+  }
+
+  OklabColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return OklabColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/oklab_color.dart
+++ b/flutter_color_models/lib/src/models/oklab_color.dart
@@ -109,7 +109,7 @@ class OklabColor extends cm.OklabColor
   }
 
   @override
-  OklabColor withValues(List<num> values) {
+  OklabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(

--- a/flutter_color_models/lib/src/models/rgb_color.dart
+++ b/flutter_color_models/lib/src/models/rgb_color.dart
@@ -111,7 +111,7 @@ class RgbColor extends cm.RgbColor
   }
 
   @override
-  RgbColor withValues(List<num> values) {
+  RgbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 255);
     assert(values[1] >= 0 && values[1] <= 255);

--- a/flutter_color_models/lib/src/models/rgb_color.dart
+++ b/flutter_color_models/lib/src/models/rgb_color.dart
@@ -24,13 +24,13 @@ class RgbColor extends cm.RgbColor
   @override
   int get value => toColor().value;
 
-  // double get a => alpha / 255.0;
+  double get a => alpha / 255.0;
 
-  // double get r => red / 255.0;
+  double get r => red / 255.0;
 
-  // double get g => green / 255.0;
+  double get g => green / 255.0;
 
-  // double get b => blue / 255.0;
+  double get b => blue / 255.0;
 
   @override
   RgbColor interpolate(cm.ColorModel end, double step) {

--- a/flutter_color_models/lib/src/models/rgb_color.dart
+++ b/flutter_color_models/lib/src/models/rgb_color.dart
@@ -24,13 +24,13 @@ class RgbColor extends cm.RgbColor
   @override
   int get value => toColor().value;
 
-  double get a => alpha / 255.0;
+  // double get a => alpha / 255.0;
 
-  double get r => toRgbColor().red / 255.0;
+  // double get r => red / 255.0;
 
-  double get g => toRgbColor().green / 255.0;
+  // double get g => green / 255.0;
 
-  double get b => toRgbColor().blue / 255.0;
+  // double get b => blue / 255.0;
 
   @override
   RgbColor interpolate(cm.ColorModel end, double step) {

--- a/flutter_color_models/lib/src/models/rgb_color.dart
+++ b/flutter_color_models/lib/src/models/rgb_color.dart
@@ -3,6 +3,7 @@ import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.RgbColor}
 class RgbColor extends cm.RgbColor
@@ -22,6 +23,14 @@ class RgbColor extends cm.RgbColor
 
   @override
   int get value => toColor().value;
+
+  double get a => alpha / 255.0;
+
+  double get r => toRgbColor().red / 255.0;
+
+  double get g => toRgbColor().green / 255.0;
+
+  double get b => toRgbColor().blue / 255.0;
 
   @override
   RgbColor interpolate(cm.ColorModel end, double step) {
@@ -118,6 +127,16 @@ class RgbColor extends cm.RgbColor
     assert(values[2] >= 0 && values[2] <= 255);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return RgbColor.fromList(values);
+  }
+
+  RgbColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return RgbColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/lib/src/models/xyz_color.dart
+++ b/flutter_color_models/lib/src/models/xyz_color.dart
@@ -112,7 +112,7 @@ class XyzColor extends cm.XyzColor
   }
 
   @override
-  XyzColor withValues(List<num> values) {
+  XyzColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/flutter_color_models/lib/src/models/xyz_color.dart
+++ b/flutter_color_models/lib/src/models/xyz_color.dart
@@ -4,6 +4,7 @@ import '../color_model.dart';
 import 'helpers/as_color.dart';
 import 'helpers/rgb_getters.dart';
 import 'helpers/cast_to_color.dart';
+import 'dart:ui' as ui;
 
 /// {@macro color_models.XyzColor}
 class XyzColor extends cm.XyzColor
@@ -119,6 +120,16 @@ class XyzColor extends cm.XyzColor
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return XyzColor.fromList(values);
+  }
+
+  XyzColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return XyzColor.fromColor(color);
   }
 
   @override

--- a/flutter_color_models/pubspec.yaml
+++ b/flutter_color_models/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A set of classes representing the CMYK, HSI, HSL, HSP, HSB, LAB,
   Oklab, RGB, and XYZ color spaces with methods to convert colors
   between each space.
-version: 1.3.3+2
+version: 1.4.0
 homepage: https://github.com/james-alex/color_models
 
 environment:
@@ -13,8 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  color_models:
-    path: ../color_models
+  color_models: ^1.4.0
   meta: ^1.7.0
 
 dev_dependencies:

--- a/flutter_color_models/pubspec.yaml
+++ b/flutter_color_models/pubspec.yaml
@@ -13,7 +13,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  color_models: ^1.3.3
+  color_models:
+    path: ../color_models
   meta: ^1.7.0
 
 dev_dependencies:


### PR DESCRIPTION
fixes https://github.com/james-alex/color_models/issues/9

changes:
  * Renames ColorModel.withValues to ColorModel.fromValues
  * Renames LabColor.a to LabColor.chromaticityA
  * Renames LabColor.b to LabColor.chromaticityB
  * Renames OklabColor.a to OklabColor.chromaticityA
  * Renames OklabColor.b to OklabColor.chromaticityB
  * Adds Color.a, Color.r, Color.g, Color.b, Color.withValues, Color.colorSpace

I chose `fromValues` instead of `withValues` since "with*" is used to mean tweaking an existing color, whereas that method is creating completely new color.