### PR TITLE
Support Flutter 3.x wide gamut changes, Fix okLab<->RGB conversions (gamma correction math was swapped),  Fixes #9, Fixes #6

### DIFF
--- a/color_models/CHANGELOG.md
+++ b/color_models/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## [2.0.0] - September 5, 2024
 
-* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `fromValues()`
-  because dart:ui Color now has a conflicting withValues() method.  Color also now has `r`, `g`, `b` and `a` getters.  This
-  forced changing of the `LabColor` and `OklabColor` classes.
-* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `chromaticityA` and `chromaticityB`
+* Added support for Flutter 3.x wide gamut changes. This necessitated changing
+  the `withValues()` method of ColorModel to become `fromValues()` because
+  dart:ui Color now has a conflicting withValues() method.  Color also now
+  has `r`, `g`, `b` and `a` getters.  This forced changing of the `LabColor`
+  and `OklabColor` classes.
+  `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b`
+  were changed to `chromaticityA` and `chromaticityB`.
 
 ## [1.3.3] - January 18, 2023
 

--- a/color_models/CHANGELOG.md
+++ b/color_models/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [2.0.0] - September 5, 2024
 
-* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `withValuesList()`
+* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `fromValues()`
   because dart:ui Color now has a conflicting withValues() method.  Color also now has `r`, `g`, `b` and `a` getters.  This
   forced changing of the `LabColor` and `OklabColor` classes.
-* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `lab_a` and `lab_b`
+* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `chromaticityA` and `chromaticityB`
 
 ## [1.3.3] - January 18, 2023
 

--- a/color_models/CHANGELOG.md
+++ b/color_models/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.0] - September 5, 2024
+
+* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `withValuesList()`
+  because dart:ui Color now has a conflicting withValues() method.  Color also now has `r`, `g`, `b` and `a` getters.  This
+  forced changing of the `LabColor` and `OklabColor` classes.
+* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `lab_a` and `lab_b`
+
 ## [1.3.3] - January 18, 2023
 
 * Added the [getColorAt] extension methods.

--- a/color_models/lib/src/color_model.dart
+++ b/color_models/lib/src/color_model.dart
@@ -92,7 +92,7 @@ abstract class ColorModel {
         : toListWithAlpha();
     final valuesB =
         end is RgbColor ? end.toPreciseListWithAlpha() : end.toListWithAlpha();
-    return withValues(List<num>.generate(valuesA.length,
+    return withValuesList(List<num>.generate(valuesA.length,
         (index) => _interpolateValue(valuesA[index], valuesB[index], step)));
   }
 
@@ -131,7 +131,7 @@ abstract class ColorModel {
       for (var j = 0; j < valuesA.length; j++) {
         values.add(_interpolateValue(valuesA[j], valuesB[j], step));
       }
-      colors.add(colorA.withValues(values));
+      colors.add(colorA.withValuesList(values));
     }
 
     if (!excludeOriginalColors) {
@@ -198,7 +198,7 @@ abstract class ColorModel {
   ///
   /// [values] should contain one value for each parameter of the color space;
   /// the alpha value is optional.
-  ColorModel withValues(List<num> values);
+  ColorModel withValuesList(List<num> values);
 
   /// Returns a copy of this color modified with the provided values.
   ColorModel copyWith({int? alpha});

--- a/color_models/lib/src/color_model.dart
+++ b/color_models/lib/src/color_model.dart
@@ -92,7 +92,7 @@ abstract class ColorModel {
         : toListWithAlpha();
     final valuesB =
         end is RgbColor ? end.toPreciseListWithAlpha() : end.toListWithAlpha();
-    return withValuesList(List<num>.generate(valuesA.length,
+    return fromValues(List<num>.generate(valuesA.length,
         (index) => _interpolateValue(valuesA[index], valuesB[index], step)));
   }
 
@@ -131,7 +131,7 @@ abstract class ColorModel {
       for (var j = 0; j < valuesA.length; j++) {
         values.add(_interpolateValue(valuesA[j], valuesB[j], step));
       }
-      colors.add(colorA.withValuesList(values));
+      colors.add(colorA.fromValues(values));
     }
 
     if (!excludeOriginalColors) {
@@ -198,7 +198,7 @@ abstract class ColorModel {
   ///
   /// [values] should contain one value for each parameter of the color space;
   /// the alpha value is optional.
-  ColorModel withValuesList(List<num> values);
+  ColorModel fromValues(List<num> values);
 
   /// Returns a copy of this color modified with the provided values.
   ColorModel copyWith({int? alpha});

--- a/color_models/lib/src/helpers/color_converter.dart
+++ b/color_models/lib/src/helpers/color_converter.dart
@@ -508,8 +508,8 @@ class ColorConverter {
   /// Converts a XYZ color to a LAB color.
   static XyzColor labToXyz(LabColor labColor) {
     final lightness = labColor.lightness;
-    final a = labColor.lab_a;
-    final b = labColor.lab_b;
+    final a = labColor.chromaticityA;
+    final b = labColor.chromaticityB;
 
     var y = (lightness + 16) / 116;
     var x = (a / 500) + y;
@@ -578,16 +578,16 @@ class ColorConverter {
     }
 
     final l = (oklabColor.lightness +
-            (0.3963377774 * oklabColor.lab_a) +
-            (0.2158037573 * oklabColor.lab_b))
+            (0.3963377774 * oklabColor.chromaticityA) +
+            (0.2158037573 * oklabColor.chromaticityB))
         .cubed();
     final m = (oklabColor.lightness -
-            (0.1055613458 * oklabColor.lab_a) -
-            (0.0638541728 * oklabColor.lab_b))
+            (0.1055613458 * oklabColor.chromaticityA) -
+            (0.0638541728 * oklabColor.chromaticityB))
         .cubed();
     final s = (oklabColor.lightness -
-            (0.0894841775 * oklabColor.lab_a) -
-            (1.2914855480 * oklabColor.lab_b))
+            (0.0894841775 * oklabColor.chromaticityA) -
+            (1.2914855480 * oklabColor.chromaticityB))
         .cubed();
 
     return _LinearRgbColor(

--- a/color_models/lib/src/helpers/color_converter.dart
+++ b/color_models/lib/src/helpers/color_converter.dart
@@ -508,8 +508,8 @@ class ColorConverter {
   /// Converts a XYZ color to a LAB color.
   static XyzColor labToXyz(LabColor labColor) {
     final lightness = labColor.lightness;
-    final a = labColor.a;
-    final b = labColor.b;
+    final a = labColor.lab_a;
+    final b = labColor.lab_b;
 
     var y = (lightness + 16) / 116;
     var x = (a / 500) + y;
@@ -578,16 +578,16 @@ class ColorConverter {
     }
 
     final l = (oklabColor.lightness +
-            (0.3963377774 * oklabColor.a) +
-            (0.2158037573 * oklabColor.b))
+            (0.3963377774 * oklabColor.lab_a) +
+            (0.2158037573 * oklabColor.lab_b))
         .cubed();
     final m = (oklabColor.lightness -
-            (0.1055613458 * oklabColor.a) -
-            (0.0638541728 * oklabColor.b))
+            (0.1055613458 * oklabColor.lab_a) -
+            (0.0638541728 * oklabColor.lab_b))
         .cubed();
     final s = (oklabColor.lightness -
-            (0.0894841775 * oklabColor.a) -
-            (1.2914855480 * oklabColor.b))
+            (0.0894841775 * oklabColor.lab_a) -
+            (1.2914855480 * oklabColor.lab_b))
         .cubed();
 
     return _LinearRgbColor(

--- a/color_models/lib/src/models/cmyk_color.dart
+++ b/color_models/lib/src/models/cmyk_color.dart
@@ -154,7 +154,7 @@ class CmykColor extends ColorModel {
   }
 
   @override
-  CmykColor withValues(List<num> values) {
+  CmykColor withValuesList(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/cmyk_color.dart
+++ b/color_models/lib/src/models/cmyk_color.dart
@@ -154,7 +154,7 @@ class CmykColor extends ColorModel {
   }
 
   @override
-  CmykColor withValuesList(List<num> values) {
+  CmykColor fromValues(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsb_color.dart
+++ b/color_models/lib/src/models/hsb_color.dart
@@ -141,7 +141,7 @@ class HsbColor extends ColorModel {
   }
 
   @override
-  HsbColor withValues(List<num> values) {
+  HsbColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsb_color.dart
+++ b/color_models/lib/src/models/hsb_color.dart
@@ -141,7 +141,7 @@ class HsbColor extends ColorModel {
   }
 
   @override
-  HsbColor withValuesList(List<num> values) {
+  HsbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsi_color.dart
+++ b/color_models/lib/src/models/hsi_color.dart
@@ -141,7 +141,7 @@ class HsiColor extends ColorModel {
   }
 
   @override
-  HsiColor withValues(List<num> values) {
+  HsiColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsi_color.dart
+++ b/color_models/lib/src/models/hsi_color.dart
@@ -141,7 +141,7 @@ class HsiColor extends ColorModel {
   }
 
   @override
-  HsiColor withValuesList(List<num> values) {
+  HsiColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsl_color.dart
+++ b/color_models/lib/src/models/hsl_color.dart
@@ -144,7 +144,7 @@ class HslColor extends ColorModel {
   }
 
   @override
-  HslColor withValues(List<num> values) {
+  HslColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsl_color.dart
+++ b/color_models/lib/src/models/hsl_color.dart
@@ -144,7 +144,7 @@ class HslColor extends ColorModel {
   }
 
   @override
-  HslColor withValuesList(List<num> values) {
+  HslColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsp_color.dart
+++ b/color_models/lib/src/models/hsp_color.dart
@@ -148,7 +148,7 @@ class HspColor extends ColorModel {
   }
 
   @override
-  HspColor withValues(List<num> values) {
+  HspColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/hsp_color.dart
+++ b/color_models/lib/src/models/hsp_color.dart
@@ -148,7 +148,7 @@ class HspColor extends ColorModel {
   }
 
   @override
-  HspColor withValuesList(List<num> values) {
+  HspColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);

--- a/color_models/lib/src/models/lab_color.dart
+++ b/color_models/lib/src/models/lab_color.dart
@@ -9,7 +9,7 @@ import '../helpers/color_math.dart';
 /// A color in the CIELAB color space.
 ///
 /// The CIELAB color space contains channels for [lightness],
-/// [a] (red and green opponent values), and [b] (blue and
+/// [lab_a] (red and green opponent values), and [lab_b] (blue and
 /// yellow opponent values.)
 ///
 /// {@endtemplate}
@@ -21,19 +21,19 @@ class LabColor extends ColorModel {
   ///
   /// [lightness] must be `>= 0` and `<= 100`.
   ///
-  /// [a] and [b] must both be `>= -128` and `<= 127`.
+  /// [lab_a] and [lab_b] must both be `>= -128` and `<= 127`.
   ///
   /// [alpha] must be `>= 0` and `<= 255`.
   ///
   /// {@endtemplate}
   const LabColor(
     this.lightness,
-    this.a,
-    this.b, [
+    this.lab_a,
+    this.lab_b, [
     int alpha = 255,
   ])  : assert(lightness >= 0 && lightness <= 100),
-        assert(a >= -128 && a <= 127),
-        assert(b >= -128 && b <= 127),
+        assert(lab_a >= -128 && lab_a <= 127),
+        assert(lab_b >= -128 && lab_b <= 127),
         assert(alpha >= 0 && alpha <= 255),
         super(alpha: alpha);
 
@@ -47,30 +47,30 @@ class LabColor extends ColorModel {
   /// Green is represented in the negative value range (`-128` to `0`)
   ///
   /// Red is represented in the positive value range (`0` to `127`)
-  final num a;
+  final num lab_a;
 
   /// The yellow to blue opponent color value.
   ///
   /// Yellow is represented int he negative value range (`-128` to `0`)
   ///
   /// Blue is represented in the positive value range (`0` to `127`)
-  final num b;
+  final num lab_b;
 
   @override
   bool get isBlack =>
       ColorMath.round(lightness) == 0 &&
-      ColorMath.round(a) == 0 &&
-      ColorMath.round(b) == 0;
+      ColorMath.round(lab_a) == 0 &&
+      ColorMath.round(lab_b) == 0;
 
   @override
   bool get isWhite =>
       ColorMath.round(lightness) == 1 &&
-      ColorMath.round(a) == 0 &&
-      ColorMath.round(b) == 0;
+      ColorMath.round(lab_a) == 0 &&
+      ColorMath.round(lab_b) == 0;
 
   @override
   bool get isMonochromatic =>
-      ColorMath.round(a) == 0 && ColorMath.round(b) == 0;
+      ColorMath.round(lab_a) == 0 && ColorMath.round(lab_b) == 0;
 
   @override
   LabColor interpolate(ColorModel end, double step) {
@@ -95,7 +95,7 @@ class LabColor extends ColorModel {
 
   @override
   LabColor get inverted => LabColor(
-      100 - lightness, 255 - (a + 128) - 128, 255 - (b + 128) - 128, alpha);
+      100 - lightness, 255 - (lab_a + 128) - 128, 255 - (lab_b + 128) - 128, alpha);
 
   @override
   LabColor get opposite => rotateHue(180);
@@ -138,7 +138,7 @@ class LabColor extends ColorModel {
   @override
   LabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return LabColor(lightness, a, b, alpha);
+    return LabColor(lightness, lab_a, lab_b, alpha);
   }
 
   @override
@@ -148,7 +148,7 @@ class LabColor extends ColorModel {
   }
 
   @override
-  LabColor withValues(List<num> values) {
+  LabColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= -128 && values[1] <= 127);
@@ -165,8 +165,8 @@ class LabColor extends ColorModel {
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return LabColor(
       lightness ?? this.lightness,
-      a ?? this.a,
-      b ?? this.b,
+      a ?? this.lab_a,
+      b ?? this.lab_b,
       alpha ?? this.alpha,
     );
   }
@@ -181,15 +181,15 @@ class LabColor extends ColorModel {
   XyzColor toXyzColor() => ColorConverter.labToXyz(this);
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [a], and [b] values, in that order.
+  /// [lab_a], and [lab_b] values, in that order.
   @override
-  List<num> toList() => List<num>.from(<num>[lightness, a, b], growable: false);
+  List<num> toList() => List<num>.from(<num>[lightness, lab_a, lab_b], growable: false);
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [a], [b], and [alpha] values, in that order.
+  /// [lab_a], [lab_b], and [alpha] values, in that order.
   @override
   List<num> toListWithAlpha() =>
-      List<num>.from(<num>[lightness, a, b, alpha], growable: false);
+      List<num>.from(<num>[lightness, lab_a, lab_b, alpha], growable: false);
 
   /// {@template color_models.LabColor.from}
   ///
@@ -259,9 +259,9 @@ class LabColor extends ColorModel {
   /// [minLightness] and [maxLightness] constrain the generated [lightness]
   /// value.
   ///
-  /// [minA] and [maxA] constrain the generated [a] value.
+  /// [minA] and [maxA] constrain the generated [lab_a] value.
   ///
-  /// [minB] and [maxB] constrain the generated [b] value.
+  /// [minB] and [maxB] constrain the generated [lab_b] value.
   ///
   /// All min and max values must be `min <= max && max >= min`, must
   /// be in the range of `>= 0 && <= 100`, and must not be `null`.
@@ -293,17 +293,17 @@ class LabColor extends ColorModel {
   LabColor convert(ColorModel other) => other.toLabColor();
 
   @override
-  String toString() => 'LabColor($lightness, $a, $b, $alpha)';
+  String toString() => 'LabColor($lightness, $lab_a, $lab_b, $alpha)';
 
   @override
   bool operator ==(Object other) =>
       other is LabColor &&
       ColorMath.round(lightness) == ColorMath.round(other.lightness) &&
-      ColorMath.round(a) == ColorMath.round(other.a) &&
-      ColorMath.round(b) == ColorMath.round(other.b) &&
+      ColorMath.round(lab_a) == ColorMath.round(other.lab_a) &&
+      ColorMath.round(lab_b) == ColorMath.round(other.lab_b) &&
       alpha == other.alpha;
 
   @override
   int get hashCode =>
-      lightness.hashCode ^ a.hashCode ^ b.hashCode ^ alpha.hashCode;
+      lightness.hashCode ^ lab_a.hashCode ^ lab_b.hashCode ^ alpha.hashCode;
 }

--- a/color_models/lib/src/models/lab_color.dart
+++ b/color_models/lib/src/models/lab_color.dart
@@ -9,7 +9,7 @@ import '../helpers/color_math.dart';
 /// A color in the CIELAB color space.
 ///
 /// The CIELAB color space contains channels for [lightness],
-/// [lab_a] (red and green opponent values), and [lab_b] (blue and
+/// [chromaticityA] (red and green opponent values), and [chromaticityB] (blue and
 /// yellow opponent values.)
 ///
 /// {@endtemplate}
@@ -21,19 +21,19 @@ class LabColor extends ColorModel {
   ///
   /// [lightness] must be `>= 0` and `<= 100`.
   ///
-  /// [lab_a] and [lab_b] must both be `>= -128` and `<= 127`.
+  /// [chromaticityA] and [chromaticityB] must both be `>= -128` and `<= 127`.
   ///
   /// [alpha] must be `>= 0` and `<= 255`.
   ///
   /// {@endtemplate}
   const LabColor(
     this.lightness,
-    this.lab_a,
-    this.lab_b, [
+    this.chromaticityA,
+    this.chromaticityB, [
     int alpha = 255,
   ])  : assert(lightness >= 0 && lightness <= 100),
-        assert(lab_a >= -128 && lab_a <= 127),
-        assert(lab_b >= -128 && lab_b <= 127),
+        assert(chromaticityA >= -128 && chromaticityA <= 127),
+        assert(chromaticityB >= -128 && chromaticityB <= 127),
         assert(alpha >= 0 && alpha <= 255),
         super(alpha: alpha);
 
@@ -47,30 +47,30 @@ class LabColor extends ColorModel {
   /// Green is represented in the negative value range (`-128` to `0`)
   ///
   /// Red is represented in the positive value range (`0` to `127`)
-  final num lab_a;
+  final num chromaticityA;
 
   /// The yellow to blue opponent color value.
   ///
   /// Yellow is represented int he negative value range (`-128` to `0`)
   ///
   /// Blue is represented in the positive value range (`0` to `127`)
-  final num lab_b;
+  final num chromaticityB;
 
   @override
   bool get isBlack =>
       ColorMath.round(lightness) == 0 &&
-      ColorMath.round(lab_a) == 0 &&
-      ColorMath.round(lab_b) == 0;
+      ColorMath.round(chromaticityA) == 0 &&
+      ColorMath.round(chromaticityB) == 0;
 
   @override
   bool get isWhite =>
       ColorMath.round(lightness) == 1 &&
-      ColorMath.round(lab_a) == 0 &&
-      ColorMath.round(lab_b) == 0;
+      ColorMath.round(chromaticityA) == 0 &&
+      ColorMath.round(chromaticityB) == 0;
 
   @override
   bool get isMonochromatic =>
-      ColorMath.round(lab_a) == 0 && ColorMath.round(lab_b) == 0;
+      ColorMath.round(chromaticityA) == 0 && ColorMath.round(chromaticityB) == 0;
 
   @override
   LabColor interpolate(ColorModel end, double step) {
@@ -95,7 +95,7 @@ class LabColor extends ColorModel {
 
   @override
   LabColor get inverted => LabColor(
-      100 - lightness, 255 - (lab_a + 128) - 128, 255 - (lab_b + 128) - 128, alpha);
+      100 - lightness, 255 - (chromaticityA + 128) - 128, 255 - (chromaticityB + 128) - 128, alpha);
 
   @override
   LabColor get opposite => rotateHue(180);
@@ -138,7 +138,7 @@ class LabColor extends ColorModel {
   @override
   LabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return LabColor(lightness, lab_a, lab_b, alpha);
+    return LabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -148,7 +148,7 @@ class LabColor extends ColorModel {
   }
 
   @override
-  LabColor withValuesList(List<num> values) {
+  LabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= -128 && values[1] <= 127);
@@ -165,8 +165,8 @@ class LabColor extends ColorModel {
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return LabColor(
       lightness ?? this.lightness,
-      a ?? this.lab_a,
-      b ?? this.lab_b,
+      a ?? this.chromaticityA,
+      b ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }
@@ -181,15 +181,15 @@ class LabColor extends ColorModel {
   XyzColor toXyzColor() => ColorConverter.labToXyz(this);
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [lab_a], and [lab_b] values, in that order.
+  /// [chromaticityA], and [chromaticityB] values, in that order.
   @override
-  List<num> toList() => List<num>.from(<num>[lightness, lab_a, lab_b], growable: false);
+  List<num> toList() => List<num>.from(<num>[lightness, chromaticityA, chromaticityB], growable: false);
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [lab_a], [lab_b], and [alpha] values, in that order.
+  /// [chromaticityA], [chromaticityB], and [alpha] values, in that order.
   @override
   List<num> toListWithAlpha() =>
-      List<num>.from(<num>[lightness, lab_a, lab_b, alpha], growable: false);
+      List<num>.from(<num>[lightness, chromaticityA, chromaticityB, alpha], growable: false);
 
   /// {@template color_models.LabColor.from}
   ///
@@ -259,9 +259,9 @@ class LabColor extends ColorModel {
   /// [minLightness] and [maxLightness] constrain the generated [lightness]
   /// value.
   ///
-  /// [minA] and [maxA] constrain the generated [lab_a] value.
+  /// [minA] and [maxA] constrain the generated [chromaticityA] value.
   ///
-  /// [minB] and [maxB] constrain the generated [lab_b] value.
+  /// [minB] and [maxB] constrain the generated [chromaticityB] value.
   ///
   /// All min and max values must be `min <= max && max >= min`, must
   /// be in the range of `>= 0 && <= 100`, and must not be `null`.
@@ -293,17 +293,17 @@ class LabColor extends ColorModel {
   LabColor convert(ColorModel other) => other.toLabColor();
 
   @override
-  String toString() => 'LabColor($lightness, $lab_a, $lab_b, $alpha)';
+  String toString() => 'LabColor($lightness, $chromaticityA, $chromaticityB, $alpha)';
 
   @override
   bool operator ==(Object other) =>
       other is LabColor &&
       ColorMath.round(lightness) == ColorMath.round(other.lightness) &&
-      ColorMath.round(lab_a) == ColorMath.round(other.lab_a) &&
-      ColorMath.round(lab_b) == ColorMath.round(other.lab_b) &&
+      ColorMath.round(chromaticityA) == ColorMath.round(other.chromaticityA) &&
+      ColorMath.round(chromaticityB) == ColorMath.round(other.chromaticityB) &&
       alpha == other.alpha;
 
   @override
   int get hashCode =>
-      lightness.hashCode ^ lab_a.hashCode ^ lab_b.hashCode ^ alpha.hashCode;
+      lightness.hashCode ^ chromaticityA.hashCode ^ chromaticityB.hashCode ^ alpha.hashCode;
 }

--- a/color_models/lib/src/models/oklab_color.dart
+++ b/color_models/lib/src/models/oklab_color.dart
@@ -10,7 +10,7 @@ import '../helpers/color_math.dart';
 /// A color in the Oklab color space.
 ///
 /// The Oklab color space contains channels for [lightness],
-/// [lab_a] (red and green opponent values), and [lab_b] (blue and
+/// [chromaticityA] (red and green opponent values), and [chromaticityB] (blue and
 /// yellow opponent values.)
 ///
 /// __See:__ https://bottosson.github.io/posts/oklab/
@@ -22,7 +22,7 @@ class OklabColor extends ColorModel {
   ///
   /// A color in the Oklab color space.
   ///
-  /// [lightness], [lab_a], and [lab_b]'s normal range is `0.0` to `1.0`,
+  /// [lightness], [chromaticityA], and [chromaticityB]'s normal range is `0.0` to `1.0`,
   /// but some colors may fall slightly outside of it.
   ///
   /// [alpha] must be `>= 0` and `<= 255`.
@@ -32,8 +32,8 @@ class OklabColor extends ColorModel {
   /// {@endtemplate}
   const OklabColor(
     this.lightness,
-    this.lab_a,
-    this.lab_b, [
+    this.chromaticityA,
+    this.chromaticityB, [
     int alpha = 255,
   ])  : assert(alpha >= 0 && alpha <= 255),
         super(alpha: alpha);
@@ -46,28 +46,28 @@ class OklabColor extends ColorModel {
   /// The red to green opponent color value.
   ///
   /// The value ranges from red at `0.0` to green at `1.0`.
-  final double lab_a;
+  final double chromaticityA;
 
   /// The yellow to blue opponent color value.
   ///
   /// The value ranges from yellow at `0.0` to blue at `1.0`.
-  final double lab_b;
+  final double chromaticityB;
 
   @override
   bool get isBlack =>
       ColorMath.round(lightness) <= 0 &&
-      ColorMath.round(lab_a) <= 0 &&
-      ColorMath.round(lab_b) <= 0;
+      ColorMath.round(chromaticityA) <= 0 &&
+      ColorMath.round(chromaticityB) <= 0;
 
   @override
   bool get isWhite =>
       ColorMath.round(lightness) >= 1 &&
-      ColorMath.round(lab_a) <= 0 &&
-      ColorMath.round(lab_b) <= 0;
+      ColorMath.round(chromaticityA) <= 0 &&
+      ColorMath.round(chromaticityB) <= 0;
 
   @override
   bool get isMonochromatic =>
-      ColorMath.round(lab_a) == 0 && ColorMath.round(lab_b) == 0;
+      ColorMath.round(chromaticityA) == 0 && ColorMath.round(chromaticityB) == 0;
 
   @override
   OklabColor interpolate(ColorModel end, double step) {
@@ -92,7 +92,7 @@ class OklabColor extends ColorModel {
 
   @override
   OklabColor get inverted =>
-      OklabColor(1.0 - lightness, 1.0 - lab_a, 1.0 - lab_b, alpha);
+      OklabColor(1.0 - lightness, 1.0 - chromaticityA, 1.0 - chromaticityB, alpha);
 
   @override
   OklabColor get opposite => rotateHue(180);
@@ -139,7 +139,7 @@ class OklabColor extends ColorModel {
   @override
   OklabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return OklabColor(lightness, lab_a, lab_b, alpha);
+    return OklabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -149,7 +149,7 @@ class OklabColor extends ColorModel {
   }
 
   @override
-  OklabColor withValuesList(List<num> values) {
+  OklabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(values);
@@ -168,8 +168,8 @@ class OklabColor extends ColorModel {
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return OklabColor(
       lightness ?? this.lightness,
-      a ?? this.lab_a,
-      b ?? this.lab_b,
+      a ?? this.chromaticityA,
+      b ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }
@@ -181,16 +181,16 @@ class OklabColor extends ColorModel {
   OklabColor toOklabColor() => this;
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [lab_a], and [lab_b] values, in that order.
+  /// [chromaticityA], and [chromaticityB] values, in that order.
   @override
   List<double> toList() =>
-      List<double>.from(<double>[lightness, lab_a, lab_b], growable: false);
+      List<double>.from(<double>[lightness, chromaticityA, chromaticityB], growable: false);
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [lab_a], [lab_b], and [alpha] values, in that order.
+  /// [chromaticityA], [chromaticityB], and [alpha] values, in that order.
   @override
   List<num> toListWithAlpha() =>
-      List<num>.from(<num>[lightness, lab_a, lab_b, alpha], growable: false);
+      List<num>.from(<num>[lightness, chromaticityA, chromaticityB, alpha], growable: false);
 
   /// {@template color_models.OklabColor.from}
   ///
@@ -234,9 +234,9 @@ class OklabColor extends ColorModel {
   /// [minLightness] and [maxLightness] constrain the generated
   /// [lightness] value.
   ///
-  /// [minA] and [maxA] constrain the generated [lab_a] value.
+  /// [minA] and [maxA] constrain the generated [chromaticityA] value.
   ///
-  /// [minB] and [maxB] constrain the generated [lab_b] value.
+  /// [minB] and [maxB] constrain the generated [chromaticityB] value.
   ///
   /// All min and max values must be `min <= max && max >= min`, must
   /// be in the range of `>= 0.0 && <= 1.0`, and must not be `null`.
@@ -262,17 +262,17 @@ class OklabColor extends ColorModel {
   OklabColor convert(ColorModel other) => other.toOklabColor();
 
   @override
-  String toString() => 'OklabColor($lightness, $lab_a, $lab_b, $alpha)';
+  String toString() => 'OklabColor($lightness, $chromaticityA, $chromaticityB, $alpha)';
 
   @override
   bool operator ==(Object other) =>
       other is OklabColor &&
       ColorMath.round(lightness) == ColorMath.round(other.lightness) &&
-      ColorMath.round(lab_a) == ColorMath.round(other.lab_a) &&
-      ColorMath.round(lab_b) == ColorMath.round(other.lab_b) &&
+      ColorMath.round(chromaticityA) == ColorMath.round(other.chromaticityA) &&
+      ColorMath.round(chromaticityB) == ColorMath.round(other.chromaticityB) &&
       alpha == other.alpha;
 
   @override
   int get hashCode =>
-      lightness.hashCode ^ lab_a.hashCode ^ lab_b.hashCode ^ alpha.hashCode;
+      lightness.hashCode ^ chromaticityA.hashCode ^ chromaticityB.hashCode ^ alpha.hashCode;
 }

--- a/color_models/lib/src/models/oklab_color.dart
+++ b/color_models/lib/src/models/oklab_color.dart
@@ -10,7 +10,7 @@ import '../helpers/color_math.dart';
 /// A color in the Oklab color space.
 ///
 /// The Oklab color space contains channels for [lightness],
-/// [a] (red and green opponent values), and [b] (blue and
+/// [lab_a] (red and green opponent values), and [lab_b] (blue and
 /// yellow opponent values.)
 ///
 /// __See:__ https://bottosson.github.io/posts/oklab/
@@ -22,7 +22,7 @@ class OklabColor extends ColorModel {
   ///
   /// A color in the Oklab color space.
   ///
-  /// [lightness], [a], and [b]'s normal range is `0.0` to `1.0`,
+  /// [lightness], [lab_a], and [lab_b]'s normal range is `0.0` to `1.0`,
   /// but some colors may fall slightly outside of it.
   ///
   /// [alpha] must be `>= 0` and `<= 255`.
@@ -32,8 +32,8 @@ class OklabColor extends ColorModel {
   /// {@endtemplate}
   const OklabColor(
     this.lightness,
-    this.a,
-    this.b, [
+    this.lab_a,
+    this.lab_b, [
     int alpha = 255,
   ])  : assert(alpha >= 0 && alpha <= 255),
         super(alpha: alpha);
@@ -46,28 +46,28 @@ class OklabColor extends ColorModel {
   /// The red to green opponent color value.
   ///
   /// The value ranges from red at `0.0` to green at `1.0`.
-  final double a;
+  final double lab_a;
 
   /// The yellow to blue opponent color value.
   ///
   /// The value ranges from yellow at `0.0` to blue at `1.0`.
-  final double b;
+  final double lab_b;
 
   @override
   bool get isBlack =>
       ColorMath.round(lightness) <= 0 &&
-      ColorMath.round(a) <= 0 &&
-      ColorMath.round(b) <= 0;
+      ColorMath.round(lab_a) <= 0 &&
+      ColorMath.round(lab_b) <= 0;
 
   @override
   bool get isWhite =>
       ColorMath.round(lightness) >= 1 &&
-      ColorMath.round(a) <= 0 &&
-      ColorMath.round(b) <= 0;
+      ColorMath.round(lab_a) <= 0 &&
+      ColorMath.round(lab_b) <= 0;
 
   @override
   bool get isMonochromatic =>
-      ColorMath.round(a) == 0 && ColorMath.round(b) == 0;
+      ColorMath.round(lab_a) == 0 && ColorMath.round(lab_b) == 0;
 
   @override
   OklabColor interpolate(ColorModel end, double step) {
@@ -92,7 +92,7 @@ class OklabColor extends ColorModel {
 
   @override
   OklabColor get inverted =>
-      OklabColor(1.0 - lightness, 1.0 - a, 1.0 - b, alpha);
+      OklabColor(1.0 - lightness, 1.0 - lab_a, 1.0 - lab_b, alpha);
 
   @override
   OklabColor get opposite => rotateHue(180);
@@ -139,7 +139,7 @@ class OklabColor extends ColorModel {
   @override
   OklabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return OklabColor(lightness, a, b, alpha);
+    return OklabColor(lightness, lab_a, lab_b, alpha);
   }
 
   @override
@@ -149,7 +149,7 @@ class OklabColor extends ColorModel {
   }
 
   @override
-  OklabColor withValues(List<num> values) {
+  OklabColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(values);
@@ -168,8 +168,8 @@ class OklabColor extends ColorModel {
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return OklabColor(
       lightness ?? this.lightness,
-      a ?? this.a,
-      b ?? this.b,
+      a ?? this.lab_a,
+      b ?? this.lab_b,
       alpha ?? this.alpha,
     );
   }
@@ -181,16 +181,16 @@ class OklabColor extends ColorModel {
   OklabColor toOklabColor() => this;
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [a], and [b] values, in that order.
+  /// [lab_a], and [lab_b] values, in that order.
   @override
   List<double> toList() =>
-      List<double>.from(<double>[lightness, a, b], growable: false);
+      List<double>.from(<double>[lightness, lab_a, lab_b], growable: false);
 
   /// Returns a fixed-length list containing the [lightness],
-  /// [a], [b], and [alpha] values, in that order.
+  /// [lab_a], [lab_b], and [alpha] values, in that order.
   @override
   List<num> toListWithAlpha() =>
-      List<num>.from(<num>[lightness, a, b, alpha], growable: false);
+      List<num>.from(<num>[lightness, lab_a, lab_b, alpha], growable: false);
 
   /// {@template color_models.OklabColor.from}
   ///
@@ -234,9 +234,9 @@ class OklabColor extends ColorModel {
   /// [minLightness] and [maxLightness] constrain the generated
   /// [lightness] value.
   ///
-  /// [minA] and [maxA] constrain the generated [a] value.
+  /// [minA] and [maxA] constrain the generated [lab_a] value.
   ///
-  /// [minB] and [maxB] constrain the generated [b] value.
+  /// [minB] and [maxB] constrain the generated [lab_b] value.
   ///
   /// All min and max values must be `min <= max && max >= min`, must
   /// be in the range of `>= 0.0 && <= 1.0`, and must not be `null`.
@@ -262,17 +262,17 @@ class OklabColor extends ColorModel {
   OklabColor convert(ColorModel other) => other.toOklabColor();
 
   @override
-  String toString() => 'OklabColor($lightness, $a, $b, $alpha)';
+  String toString() => 'OklabColor($lightness, $lab_a, $lab_b, $alpha)';
 
   @override
   bool operator ==(Object other) =>
       other is OklabColor &&
       ColorMath.round(lightness) == ColorMath.round(other.lightness) &&
-      ColorMath.round(a) == ColorMath.round(other.a) &&
-      ColorMath.round(b) == ColorMath.round(other.b) &&
+      ColorMath.round(lab_a) == ColorMath.round(other.lab_a) &&
+      ColorMath.round(lab_b) == ColorMath.round(other.lab_b) &&
       alpha == other.alpha;
 
   @override
   int get hashCode =>
-      lightness.hashCode ^ a.hashCode ^ b.hashCode ^ alpha.hashCode;
+      lightness.hashCode ^ lab_a.hashCode ^ lab_b.hashCode ^ alpha.hashCode;
 }

--- a/color_models/lib/src/models/rgb_color.dart
+++ b/color_models/lib/src/models/rgb_color.dart
@@ -151,7 +151,7 @@ class RgbColor extends ColorModel {
   }
 
   @override
-  RgbColor withValues(List<num> values) {
+  RgbColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 255);
     assert(values[1] >= 0 && values[1] <= 255);

--- a/color_models/lib/src/models/rgb_color.dart
+++ b/color_models/lib/src/models/rgb_color.dart
@@ -151,7 +151,7 @@ class RgbColor extends ColorModel {
   }
 
   @override
-  RgbColor withValuesList(List<num> values) {
+  RgbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 255);
     assert(values[1] >= 0 && values[1] <= 255);

--- a/color_models/lib/src/models/xyz_color.dart
+++ b/color_models/lib/src/models/xyz_color.dart
@@ -154,7 +154,7 @@ class XyzColor extends ColorModel {
   }
 
   @override
-  XyzColor withValuesList(List<num> values) {
+  XyzColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0);
     assert(values[1] >= 0);

--- a/color_models/lib/src/models/xyz_color.dart
+++ b/color_models/lib/src/models/xyz_color.dart
@@ -154,7 +154,7 @@ class XyzColor extends ColorModel {
   }
 
   @override
-  XyzColor withValues(List<num> values) {
+  XyzColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0);
     assert(values[1] >= 0);

--- a/color_models/pubspec.yaml
+++ b/color_models/pubspec.yaml
@@ -3,11 +3,11 @@ description: >-
   A set of classes representing the CMYK, HSI, HSL, HSP, HSB, LAB,
   Oklab, RGB, and XYZ color spaces with methods to convert colors
   between each space.
-version: 1.3.3
+version: 2.0.0
 homepage: https://github.com/james-alex/color_models
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   meta: ^1.7.0

--- a/flutter_color_models/CHANGELOG.md
+++ b/flutter_color_models/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## [2.0.0] - September 5, 2024
 
-* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `withValuesList()`
+* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `fromValues()`
   because dart:ui Color now has a conflicting withValues() method.  Color also now has `r`, `g`, `b` and `a` getters.  This
   forced changing of the `LabColor` and `OklabColor` classes.
 * addition of `withValues()` override method to `CmykColor`, `HsbColor`, `HsiColor`, `HslColor`, `HspColor`, `LabColor`,
   `OklabColor`, `RgbColor` and `XyzColor` classes so they could continue to extend `ColorModel` which implements `ui.Color` (which now
   has this member method)
-* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `lab_a` and `lab_b`
+* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `chromaticityA` and `chromaticityB`
 * add factory constructor to `ColorModel` that takes a `ui.Color` object (so `Colors.XXXX` could be used in creating `ColorModel`s
 * Addition of `a`, `r`, `g`, `b` and `colorSpace` getters to continue to support extending `ui.Color`
 * Addition of `UICloned_getColorTransform()` function and supporting `UICloned_XXXX` classes/functions

--- a/flutter_color_models/CHANGELOG.md
+++ b/flutter_color_models/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.0.0] - September 5, 2024
+
+* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `withValuesList()`
+  because dart:ui Color now has a conflicting withValues() method.  Color also now has `r`, `g`, `b` and `a` getters.  This
+  forced changing of the `LabColor` and `OklabColor` classes.
+* addition of `withValues()` override method to `CmykColor`, `HsbColor`, `HsiColor`, `HslColor`, `HspColor`, `LabColor`,
+  `OklabColor`, `RgbColor` and `XyzColor` classes so they could continue to extend `ColorModel` which implements `ui.Color` (which now
+  has this member method)
+* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `lab_a` and `lab_b`
+* add factory constructor to `ColorModel` that takes a `ui.Color` object (so `Colors.XXXX` could be used in creating `ColorModel`s
+* Addition of `a`, `r`, `g`, `b` and `colorSpace` getters to continue to support extending `ui.Color`
+* Addition of `UICloned_getColorTransform()` function and supporting `UICloned_XXXX` classes/functions
+
 ## [1.3.3] - January 18, 2023
 
 * Added the [toColors] helper method to [Iterable<ColorModel>].

--- a/flutter_color_models/CHANGELOG.md
+++ b/flutter_color_models/CHANGELOG.md
@@ -1,16 +1,22 @@
 ## [2.0.0] - September 5, 2024
 
-* Added support for Flutter 3.x - this necessitated changing the `withValues()` method of ColorModel to become `fromValues()`
-  because dart:ui Color now has a conflicting withValues() method.  Color also now has `r`, `g`, `b` and `a` getters.  This
-  forced changing of the `LabColor` and `OklabColor` classes.
-* addition of `withValues()` override method to `CmykColor`, `HsbColor`, `HsiColor`, `HslColor`, `HspColor`, `LabColor`,
-  `OklabColor`, `RgbColor` and `XyzColor` classes so they could continue to extend `ColorModel` which implements `ui.Color` (which now
-  has this member method)
-* `LabColor` and `OklabColor` had to have the chromaticity members `a` and `b` were changed to `chromaticityA` and `chromaticityB`
-* add factory constructor to `ColorModel` that takes a `ui.Color` object (so `Colors.XXXX` could be used in creating `ColorModel`s
-* Addition of `a`, `r`, `g`, `b` and `colorSpace` getters to continue to support extending `ui.Color`
-* Addition of `UICloned_getColorTransform()` function and supporting `UICloned_XXXX` classes/functions
-
+* Added support for Flutter 3.x wide gamut changes. This necessitated changing 
+  the `withValues()` method of ColorModel to become `fromValues()`
+  because dart:ui Color now has a conflicting withValues() method.  Color also
+  now has `r`, `g`, `b` and `a` getters.  This forced changing of the
+  `LabColor` and `OklabColor` classes.
+  addition of `withValues()` override method to `CmykColor`, `HsbColor`,
+  `HsiColor`, `HslColor`, `HspColor`, `LabColor`,
+  `OklabColor`, `RgbColor` and `XyzColor` classes so they could continue
+   to extend `ColorModel` which implements `ui.Color` (which now
+   has this member method)
+  `LabColor` and `OklabColor` had to have the chromaticity members `a`
+  and `b` were changed to `chromaticityA` and `chromaticityB`
+  Addition of `a`, `r`, `g`, `b` and `colorSpace` getters to continue to
+  support extending `ui.Color`
+* add factory constructor to `ColorModel` that takes a `ui.Color` object
+  (so `Colors.XXXX` could be used in creating `ColorModel`s
+  
 ## [1.3.3] - January 18, 2023
 
 * Added the [toColors] helper method to [Iterable<ColorModel>].

--- a/flutter_color_models/lib/src/color_model.dart
+++ b/flutter_color_models/lib/src/color_model.dart
@@ -135,7 +135,7 @@ extension LerpToColor on Color {
   }) {
     assert(steps > 0);
     return toRgbColor().lerpTo(color.toRgbColor(), steps,
-        colorSpace: colorSpace, excludeOriginalColors: excludeOriginalColors) as List<Color>;
+        colorSpace: colorSpace, excludeOriginalColors: excludeOriginalColors);
   }
 
   /// Interpolates to the defined [step] between this color and [end].
@@ -335,7 +335,7 @@ extension AugmentColors on Iterable<Color> {
   }) {
     assert(stops == null || stops.length == length);
     return toColorModels().cast<ColorModel>().augment(newLength,
-        stops: stops, colorSpace: colorSpace, invert: invert) as List<Color>;
+        stops: stops, colorSpace: colorSpace, invert: invert);
   }
 
   /// Returns this iterable as a list of [ColorModel]s.

--- a/flutter_color_models/lib/src/color_model.dart
+++ b/flutter_color_models/lib/src/color_model.dart
@@ -74,7 +74,7 @@ abstract class ColorModel implements cm.ColorModel, Color {
   ColorModel withOpacity(double opacity);
 
   @override
-  ColorModel withValuesList(List<num> values);
+  ColorModel fromValues(List<num> values);
 
   @override
   ColorModel copyWith({int? alpha});
@@ -108,121 +108,6 @@ abstract class ColorModel implements cm.ColorModel, Color {
 
   @override
   ColorModel convert(cm.ColorModel other);
-}
-
-abstract class UICloned_ColorTransform {
-  Color transform(Color color, ui.ColorSpace resultColorSpace);
-}
-
-class UICloned_IdentityColorTransform implements UICloned_ColorTransform {
-  const UICloned_IdentityColorTransform();
-  @override
-  Color transform(Color color, ui.ColorSpace resultColorSpace) => color;
-}
-
-class UICloned_ClampTransform implements UICloned_ColorTransform {
-  const UICloned_ClampTransform(this.child);
-  final UICloned_ColorTransform child;
-  @override
-  Color transform(Color color, ui.ColorSpace resultColorSpace) {
-    return Color.from(
-      alpha: ui.clampDouble(color.a, 0, 1),
-      red: ui.clampDouble(color.r, 0, 1),
-      green: ui.clampDouble(color.g, 0, 1),
-      blue: ui.clampDouble(color.b, 0, 1),
-      colorSpace: resultColorSpace);
-  }
-}
-
-class UICloned_MatrixColorTransform implements UICloned_ColorTransform {
-  /// Row-major.
-  const UICloned_MatrixColorTransform(this.values);
-
-  final List<double> values;
-
-  @override
-  Color transform(Color color, ui.ColorSpace resultColorSpace) {
-    return Color.from(
-        alpha: color.a,
-        red: values[0] * color.r +
-            values[1] * color.g +
-            values[2] * color.b +
-            values[3],
-        green: values[4] * color.r +
-            values[5] * color.g +
-            values[6] * color.b +
-            values[7],
-        blue: values[8] * color.r +
-            values[9] * color.g +
-            values[10] * color.b +
-            values[11],
-        colorSpace: resultColorSpace);
-  }
-}
-
-UICloned_ColorTransform UICloned_getColorTransform(ui.ColorSpace source, ui.ColorSpace destination) {
-  // The transforms were calculated with the following octave script from known
-  // conversions. These transforms have a white point that matches Apple's.
-  //
-  // p3Colors = [
-  //   1, 0, 0, 0.25;
-  //   0, 1, 0, 0.5;
-  //   0, 0, 1, 0.75;
-  //   1, 1, 1, 1;
-  // ];
-  // srgbColors = [
-  //   1.0930908918380737,  -0.5116420984268188, -0.0003518527664709836, 0.12397786229848862;
-  //   -0.22684034705162048, 1.0182716846466064,  0.00027732315356843174,  0.5073589086532593;
-  //   -0.15007957816123962, -0.31062406301498413, 1.0420056581497192,  0.771118700504303;
-  //   1,       1,       1,       1;
-  // ];
-  //
-  // format long
-  // p3ToSrgb = srgbColors * inv(p3Colors)
-  // srgbToP3 = inv(p3ToSrgb)
-  const UICloned_MatrixColorTransform srgbToP3 = UICloned_MatrixColorTransform(<double>[
-    0.808052267214446, 0.220292047628890, -0.139648846160100,
-    0.145738111193222, //
-    0.096480880462996, 0.916386732581291, -0.086093928394828,
-    0.089490172325882, //
-    -0.127099563510240, -0.068983484963878, 0.735426667591299, 0.233655661600230
-  ]);
-  const UICloned_ColorTransform p3ToSrgb = UICloned_MatrixColorTransform(<double>[
-    1.306671048092539, -0.298061942172353, 0.213228303487995,
-    -0.213580156254466, //
-    -0.117390025596251, 1.127722006101976, 0.109727644608938,
-    -0.109450321455370, //
-    0.214813187718391, 0.054268702864647, 1.406898424029350, -0.364892765879631
-  ]);
-  switch (source) {
-    case ui.ColorSpace.sRGB:
-      switch (destination) {
-        case ui.ColorSpace.sRGB:
-          return const UICloned_IdentityColorTransform();
-        case ui.ColorSpace.extendedSRGB:
-          return const UICloned_IdentityColorTransform();
-        case ui.ColorSpace.displayP3:
-          return srgbToP3;
-      }
-    case ui.ColorSpace.extendedSRGB:
-      switch (destination) {
-        case ui.ColorSpace.sRGB:
-          return const UICloned_ClampTransform(UICloned_IdentityColorTransform());
-        case ui.ColorSpace.extendedSRGB:
-          return const UICloned_IdentityColorTransform();
-        case ui.ColorSpace.displayP3:
-          return const UICloned_ClampTransform(srgbToP3);
-      }
-    case ui.ColorSpace.displayP3:
-      switch (destination) {
-        case ui.ColorSpace.sRGB:
-          return const UICloned_ClampTransform(p3ToSrgb);
-        case ui.ColorSpace.extendedSRGB:
-          return p3ToSrgb;
-        case ui.ColorSpace.displayP3:
-          return const UICloned_IdentityColorTransform();
-      }
-  }
 }
 
 extension ToColor on cm.ColorModel {

--- a/flutter_color_models/lib/src/models/cmyk_color.dart
+++ b/flutter_color_models/lib/src/models/cmyk_color.dart
@@ -113,44 +113,25 @@ class CmykColor extends cm.CmykColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  CmykColor withValuesList(List<num> values) {
+  CmykColor fromValues(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);
     assert(values[2] >= 0 && values[2] <= 100);
     assert(values[3] >= 0 && values[3] <= 100);
     return CmykColor.fromList(values);
+  }
+
+  @override
+  CmykColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return CmykColor.fromColor(color);
   }
 
   @override
@@ -181,7 +162,7 @@ class CmykColor extends cm.CmykColor
   /// {@macro color_models.CmykColor.from}
   factory CmykColor.from(cm.ColorModel color) => color.toCmykColor().cast();
 
-  /// {@macro color_models.CmykColor.fromList}
+  /// {@macro color_models.CmykColor.fromValues}
   factory CmykColor.fromList(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
@@ -248,25 +229,5 @@ class CmykColor extends cm.CmykColor
 
   @override
   CmykColor convert(cm.ColorModel other) => other.toCmykColor().cast();
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
-    
+  
 }

--- a/flutter_color_models/lib/src/models/cmyk_color.dart
+++ b/flutter_color_models/lib/src/models/cmyk_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui hide Color;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -112,8 +113,38 @@ class CmykColor extends cm.CmykColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  CmykColor withValues(List<num> values) {
+  CmykColor withValuesList(List<num> values) {
     assert(values.length == 4 || values.length == 5);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);
@@ -217,4 +248,25 @@ class CmykColor extends cm.CmykColor
 
   @override
   CmykColor convert(cm.ColorModel other) => other.toCmykColor().cast();
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
+    
 }

--- a/flutter_color_models/lib/src/models/helpers/as_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/as_color.dart
@@ -1,6 +1,30 @@
 import 'package:color_models/color_models.dart' show ColorModel;
 import 'package:flutter/painting.dart' show Color;
 import 'dart:math' as math show pow;
+import 'dart:ui' as ui hide Color;
+
+extension ColorModelWithValues on ColorModel {
+  Color performWithValues(double? alpha, double? red, double? green,
+      double? blue, ui.ColorSpace? colorSpace) {
+    // TODO(gaaclarke): This is inefficient and will be easier to rewrite once
+    // the changes come through on Color.
+    assert(colorSpace == null || colorSpace == ui.ColorSpace.sRGB);
+    Color color = toRgbColor() as Color;
+    if (alpha != null) {
+      color = color.withAlpha(alpha ~/ 255.0);
+    }
+    if (red != null) {
+      color = color.withRed(red ~/ 255.0);
+    }
+    if (green != null) {
+      color = color.withGreen(green ~/ 255.0);
+    }
+    if (blue != null) {
+      color = color.withBlue(blue ~/ 255.0);
+    }
+    return color;
+  }
+}
 
 /// The getters and methods required to implement Flutter's [Color] class.
 mixin AsColor on ColorModel {
@@ -13,6 +37,8 @@ mixin AsColor on ColorModel {
   /// * Bits 8-15 are the green value.
   /// * Bits 0-7 are the blue value.
   int get value;
+
+  ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
 
   /// See <https://www.w3.org/TR/WCAG20/#relativeluminancedef>
   ///

--- a/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
@@ -188,7 +188,7 @@ extension CastFromHspColor on HspColor {
 extension CastToLabColor on cm.LabColor {
   /// Casts a [LabColor] from the `color_models` package to a
   /// [LabColor] from the `flutter_color_models` package.
-  LabColor cast() => LabColor(lightness, a, b, alpha);
+  LabColor cast() => LabColor(lightness, lab_a, lab_b, alpha);
 }
 
 extension CastFromLabColor on LabColor {
@@ -200,13 +200,13 @@ extension CastFromLabColor on LabColor {
 extension CastToOklabColor on cm.OklabColor {
   /// Casts a [OklabColor] from the `color_models` package to a
   /// [OklabColor] from the `flutter_color_models` package.
-  OklabColor cast() => OklabColor(lightness, a, b, alpha);
+  OklabColor cast() => OklabColor(lightness, lab_a, lab_b, alpha);
 }
 
 extension CastFromOklabColor on OklabColor {
   /// Casts a [OklabColor] from the `color_models` package to a
   /// [OklabColor] from the `flutter_color_models` package.
-  cm.OklabColor cast() => cm.OklabColor(lightness, a, b, alpha);
+  cm.OklabColor cast() => cm.OklabColor(lightness, lab_a, lab_b, alpha);
 }
 
 extension CastToRgbColor on cm.RgbColor {

--- a/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
+++ b/flutter_color_models/lib/src/models/helpers/cast_to_color.dart
@@ -188,7 +188,7 @@ extension CastFromHspColor on HspColor {
 extension CastToLabColor on cm.LabColor {
   /// Casts a [LabColor] from the `color_models` package to a
   /// [LabColor] from the `flutter_color_models` package.
-  LabColor cast() => LabColor(lightness, lab_a, lab_b, alpha);
+  LabColor cast() => LabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastFromLabColor on LabColor {
@@ -200,13 +200,13 @@ extension CastFromLabColor on LabColor {
 extension CastToOklabColor on cm.OklabColor {
   /// Casts a [OklabColor] from the `color_models` package to a
   /// [OklabColor] from the `flutter_color_models` package.
-  OklabColor cast() => OklabColor(lightness, lab_a, lab_b, alpha);
+  OklabColor cast() => OklabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastFromOklabColor on OklabColor {
   /// Casts a [OklabColor] from the `color_models` package to a
   /// [OklabColor] from the `flutter_color_models` package.
-  cm.OklabColor cast() => cm.OklabColor(lightness, lab_a, lab_b, alpha);
+  cm.OklabColor cast() => cm.OklabColor(lightness, chromaticityA, chromaticityB, alpha);
 }
 
 extension CastToRgbColor on cm.RgbColor {

--- a/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
+++ b/flutter_color_models/lib/src/models/helpers/rgb_getters.dart
@@ -9,4 +9,12 @@ mixin RgbGetters on ColorModel {
 
   /// The blue value of this color.
   int get blue => toRgbColor().blue;
+
+  double get a => alpha / 255.0;
+
+  double get r => red / 255.0;
+
+  double get g => green / 255.0;
+
+  double get b => blue / 255.0;
 }

--- a/flutter_color_models/lib/src/models/hsb_color.dart
+++ b/flutter_color_models/lib/src/models/hsb_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -9,6 +10,7 @@ import 'helpers/cast_to_color.dart';
 class HsbColor extends cm.HsbColor
     with AsColor, RgbGetters, CastToColor
     implements ColorModel {
+
   /// {@macro color_models.HsbColor.constructor}
   const HsbColor(
     num hue,
@@ -109,8 +111,38 @@ class HsbColor extends cm.HsbColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  HsbColor withValues(List<num> values) {
+  HsbColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
@@ -202,4 +234,25 @@ class HsbColor extends cm.HsbColor
 
   @override
   HsbColor convert(cm.ColorModel other) => other.toHsbColor().cast();
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
+    
 }

--- a/flutter_color_models/lib/src/models/hsb_color.dart
+++ b/flutter_color_models/lib/src/models/hsb_color.dart
@@ -111,44 +111,25 @@ class HsbColor extends cm.HsbColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  HsbColor withValuesList(List<num> values) {
+  HsbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HsbColor.fromList(values);
+  }
+
+  @override
+  HsbColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HsbColor.fromColor(color);
   }
 
   @override
@@ -234,25 +215,5 @@ class HsbColor extends cm.HsbColor
 
   @override
   HsbColor convert(cm.ColorModel other) => other.toHsbColor().cast();
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
-    
+  
 }

--- a/flutter_color_models/lib/src/models/hsi_color.dart
+++ b/flutter_color_models/lib/src/models/hsi_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -109,8 +110,38 @@ class HsiColor extends cm.HsiColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  HsiColor withValues(List<num> values) {
+  HsiColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
@@ -197,4 +228,24 @@ class HsiColor extends cm.HsiColor
 
   @override
   HsiColor convert(cm.ColorModel other) => other.toHsiColor().cast();
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
 }

--- a/flutter_color_models/lib/src/models/hsi_color.dart
+++ b/flutter_color_models/lib/src/models/hsi_color.dart
@@ -110,44 +110,25 @@ class HsiColor extends cm.HsiColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  HsiColor withValuesList(List<num> values) {
+  HsiColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HsiColor.fromList(values);
+  }
+
+  @override
+  HsiColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HsiColor.fromColor(color);
   }
 
   @override
@@ -229,23 +210,4 @@ class HsiColor extends cm.HsiColor
   @override
   HsiColor convert(cm.ColorModel other) => other.toHsiColor().cast();
 
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
 }

--- a/flutter_color_models/lib/src/models/hsl_color.dart
+++ b/flutter_color_models/lib/src/models/hsl_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -108,9 +109,38 @@ class HslColor extends cm.HslColor
     assert(opacity >= 0.0 && opacity <= 1.0);
     return copyWith(alpha: (opacity * 255).round());
   }
-
+  
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
   @override
-  HslColor withValues(List<num> values) {
+  HslColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
@@ -197,4 +227,24 @@ class HslColor extends cm.HslColor
 
   @override
   HslColor convert(cm.ColorModel other) => other.toHslColor().cast();
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
 }

--- a/flutter_color_models/lib/src/models/hsl_color.dart
+++ b/flutter_color_models/lib/src/models/hsl_color.dart
@@ -110,43 +110,25 @@ class HslColor extends cm.HslColor
     return copyWith(alpha: (opacity * 255).round());
   }
   
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
   @override
-  HslColor withValuesList(List<num> values) {
+  HslColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HslColor.fromList(values);
+  }
+
+  @override
+  HslColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HslColor.fromColor(color);
   }
 
   @override
@@ -228,23 +210,4 @@ class HslColor extends cm.HslColor
   @override
   HslColor convert(cm.ColorModel other) => other.toHslColor().cast();
 
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
 }

--- a/flutter_color_models/lib/src/models/hsp_color.dart
+++ b/flutter_color_models/lib/src/models/hsp_color.dart
@@ -110,44 +110,25 @@ class HspColor extends cm.HspColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  HspColor withValuesList(List<num> values) {
+  HspColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return HspColor.fromList(values);
+  }
+
+  @override
+  HspColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return HspColor.fromColor(color);
   }
 
   @override
@@ -236,26 +217,5 @@ class HspColor extends cm.HspColor
 
   @override
   HspColor convert(cm.ColorModel other) => other.toHspColor().cast();
-
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
     
 }

--- a/flutter_color_models/lib/src/models/hsp_color.dart
+++ b/flutter_color_models/lib/src/models/hsp_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -109,8 +110,38 @@ class HspColor extends cm.HspColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  HspColor withValues(List<num> values) {
+  HspColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 360);
     assert(values[1] >= 0 && values[1] <= 100);
@@ -205,4 +236,26 @@ class HspColor extends cm.HspColor
 
   @override
   HspColor convert(cm.ColorModel other) => other.toHspColor().cast();
+
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
+    
 }

--- a/flutter_color_models/lib/src/models/lab_color.dart
+++ b/flutter_color_models/lib/src/models/lab_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -111,8 +112,38 @@ class LabColor extends cm.LabColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  LabColor withValues(List<num> values) {
+  LabColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= -128 && values[1] <= 127);
@@ -200,4 +231,26 @@ class LabColor extends cm.LabColor
 
   @override
   LabColor convert(cm.ColorModel other) => other.toLabColor().cast();
+
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
+    
 }

--- a/flutter_color_models/lib/src/models/lab_color.dart
+++ b/flutter_color_models/lib/src/models/lab_color.dart
@@ -112,44 +112,25 @@ class LabColor extends cm.LabColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  LabColor withValuesList(List<num> values) {
+  LabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= -128 && values[1] <= 127);
     assert(values[2] >= -128 && values[2] <= 127);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return LabColor.fromList(values);
+  }
+
+  @override
+  LabColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return LabColor.fromColor(color);
   }
 
   @override
@@ -231,26 +212,5 @@ class LabColor extends cm.LabColor
 
   @override
   LabColor convert(cm.ColorModel other) => other.toLabColor().cast();
-
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
     
 }

--- a/flutter_color_models/lib/src/models/oklab_color.dart
+++ b/flutter_color_models/lib/src/models/oklab_color.dart
@@ -100,7 +100,7 @@ class OklabColor extends cm.OklabColor
   @override
   OklabColor withAlpha(int alpha) {
     assert(alpha >= 0 && alpha <= 255);
-    return OklabColor(lightness, lab_a, lab_b, alpha);
+    return OklabColor(lightness, chromaticityA, chromaticityB, alpha);
   }
 
   @override
@@ -109,44 +109,24 @@ class OklabColor extends cm.OklabColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  OklabColor withValuesList(List<num> values) {
+  OklabColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return OklabColor.fromList(
         values.map<double>((value) => value.toDouble()).toList());
   }
 
+  OklabColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return OklabColor.fromColor(color);
+  }
+  
   @override
   OklabColor copyWith({num? lightness, num? a, num? b, int? alpha}) {
     assert(lightness == null || (lightness >= 0.0 && lightness <= 1.0));
@@ -155,8 +135,8 @@ class OklabColor extends cm.OklabColor
     assert(alpha == null || (alpha >= 0 && alpha <= 255));
     return OklabColor(
       lightness?.toDouble() ?? this.lightness,
-      a?.toDouble() ?? this.lab_a,
-      b?.toDouble() ?? this.lab_b,
+      a?.toDouble() ?? this.chromaticityA,
+      b?.toDouble() ?? this.chromaticityB,
       alpha ?? this.alpha,
     );
   }
@@ -205,25 +185,5 @@ class OklabColor extends cm.OklabColor
 
   @override
   OklabColor convert(cm.ColorModel other) => other.toOklabColor().cast();
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
     
 }

--- a/flutter_color_models/lib/src/models/rgb_color.dart
+++ b/flutter_color_models/lib/src/models/rgb_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -110,8 +111,38 @@ class RgbColor extends cm.RgbColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  RgbColor withValues(List<num> values) {
+  RgbColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 255);
     assert(values[1] >= 0 && values[1] <= 255);
@@ -198,4 +229,25 @@ class RgbColor extends cm.RgbColor
 
   @override
   RgbColor convert(cm.ColorModel other) => other.toRgbColor().cast();
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
+    
 }

--- a/flutter_color_models/lib/src/models/rgb_color.dart
+++ b/flutter_color_models/lib/src/models/rgb_color.dart
@@ -25,6 +25,18 @@ class RgbColor extends cm.RgbColor
   int get value => toColor().value;
 
   @override
+  double get a => alpha / 255.0;
+
+  @override
+  double get r => red / 255.0;
+
+  @override
+  double get g => green / 255.0;
+
+  @override
+  double get b => blue / 255.0;
+
+  @override
   RgbColor interpolate(cm.ColorModel end, double step) {
     assert(step >= 0.0 && step <= 1.0);
     return super.interpolate(end, step).cast();
@@ -111,44 +123,25 @@ class RgbColor extends cm.RgbColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  RgbColor withValuesList(List<num> values) {
+  RgbColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 255);
     assert(values[1] >= 0 && values[1] <= 255);
     assert(values[2] >= 0 && values[2] <= 255);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return RgbColor.fromList(values);
+  }
+
+  @override
+  RgbColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return RgbColor.fromColor(color);
   }
 
   @override
@@ -229,25 +222,5 @@ class RgbColor extends cm.RgbColor
 
   @override
   RgbColor convert(cm.ColorModel other) => other.toRgbColor().cast();
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
-    
+  
 }

--- a/flutter_color_models/lib/src/models/xyz_color.dart
+++ b/flutter_color_models/lib/src/models/xyz_color.dart
@@ -112,44 +112,25 @@ class XyzColor extends cm.XyzColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
-  // We must override this withValues from Color, has this from dart ui
-  /// Returns a new color that matches this color with the passed in components
-  /// changed.
-  ///
-  /// Changes to color components will be applied before applying changes to the
-  /// color space.
-  Color withValues(
-      {double? alpha,
-      double? red,
-      double? green,
-      double? blue,
-      ui.ColorSpace? colorSpace}) {
-    Color? updatedComponents;
-    if (alpha != null || red != null || green != null || blue != null) {
-      updatedComponents = Color.from(
-          alpha: alpha ?? a,
-          red: red ?? r,
-          green: green ?? g,
-          blue: blue ?? b,
-          colorSpace: this.colorSpace);
-    }
-    if (colorSpace != null && colorSpace != this.colorSpace) {
-      final UICloned_ColorTransform transform =
-          UICloned_getColorTransform(this.colorSpace, colorSpace);
-      return transform.transform(updatedComponents ?? this, colorSpace);
-    } else {
-      return updatedComponents ?? this;
-    }
-  }
-  
   @override
-  XyzColor withValuesList(List<num> values) {
+  XyzColor fromValues(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);
     assert(values[2] >= 0 && values[2] <= 100);
     if (values.length == 4) assert(values[3] >= 0 && values[3] <= 255);
     return XyzColor.fromList(values);
+  }
+
+  @override
+  XyzColor withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color color = performWithValues(alpha, red, green, blue, colorSpace);
+    return XyzColor.fromColor(color);
   }
 
   @override
@@ -235,25 +216,5 @@ class XyzColor extends cm.XyzColor
 
   @override
   XyzColor convert(cm.ColorModel other) => other.toXyzColor().cast();
-
-  //OVERRIDEs for painting.dart Color
-  @override
-  double get a => (alpha / 255);
-
-  /// The red channel of this color.
-  @override
-  double get r =>(red / 255);
-
-  /// The green channel of this color.
-  @override
-  double get g => (green / 255);
-
-  /// The blue channel of this color.
-  @override
-  double get b => (blue / 255);
-
-  /// The color space of this color.
-  @override
-  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
     
 }

--- a/flutter_color_models/lib/src/models/xyz_color.dart
+++ b/flutter_color_models/lib/src/models/xyz_color.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart' show Color;
 import 'package:color_models/color_models.dart' as cm;
 import '../color_model.dart';
@@ -111,8 +112,38 @@ class XyzColor extends cm.XyzColor
     return copyWith(alpha: (opacity * 255).round());
   }
 
+  // We must override this withValues from Color, has this from dart ui
+  /// Returns a new color that matches this color with the passed in components
+  /// changed.
+  ///
+  /// Changes to color components will be applied before applying changes to the
+  /// color space.
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ui.ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final UICloned_ColorTransform transform =
+          UICloned_getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+  
   @override
-  XyzColor withValues(List<num> values) {
+  XyzColor withValuesList(List<num> values) {
     assert(values.length == 3 || values.length == 4);
     assert(values[0] >= 0 && values[0] <= 100);
     assert(values[1] >= 0 && values[1] <= 100);
@@ -204,4 +235,25 @@ class XyzColor extends cm.XyzColor
 
   @override
   XyzColor convert(cm.ColorModel other) => other.toXyzColor().cast();
+
+  //OVERRIDEs for painting.dart Color
+  @override
+  double get a => (alpha / 255);
+
+  /// The red channel of this color.
+  @override
+  double get r =>(red / 255);
+
+  /// The green channel of this color.
+  @override
+  double get g => (green / 255);
+
+  /// The blue channel of this color.
+  @override
+  double get b => (blue / 255);
+
+  /// The color space of this color.
+  @override
+  final ui.ColorSpace colorSpace=ui.ColorSpace.sRGB;
+    
 }

--- a/flutter_color_models/pubspec.yaml
+++ b/flutter_color_models/pubspec.yaml
@@ -3,17 +3,20 @@ description: >-
   A set of classes representing the CMYK, HSI, HSL, HSP, HSB, LAB,
   Oklab, RGB, and XYZ color spaces with methods to convert colors
   between each space.
-version: 1.3.3+2
+version: 2.0.0
 homepage: https://github.com/james-alex/color_models
+publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  color_models: ^1.3.3
+  color_models: #^2.0.0
+    path: ../color_models
+
   meta: ^1.7.0
 
 dev_dependencies:


### PR DESCRIPTION
Flutter 3.x added additional members to the ui.Color class (`withValues()` method and `r`, `g`, `b`, and `a `getters.  This necessitated changes to change the existing `withValues()` method to `withValuesList()` and adding getters for r`, `g`, `b`, and `a `.  This also required renaming the existing `a` and `b` chromaticity getters for `LabColor` and `OklabColor` to `lab_a` and `lab_b`.
